### PR TITLE
check format of vague numbers. fixed yearsuffix equal to 0. fixed tru…

### DIFF
--- a/src/main/scala/info/bethard/timenorm/formal/Readers.scala
+++ b/src/main/scala/info/bethard/timenorm/formal/Readers.scala
@@ -54,7 +54,8 @@ class AnaforaReader(val DCT: Interval)(implicit data: Data) {
       } else if (value.forall(_.isDigit)) {
         IntNumber(value.toInt)
       } else {
-        VagueNumber(value)
+        throw new AnaforaReader.Exception(
+        s"""cannot parse number "${entity.text}""")
       }
   }
 

--- a/src/main/scala/info/bethard/timenorm/formal/Types.scala
+++ b/src/main/scala/info/bethard/timenorm/formal/Types.scala
@@ -233,7 +233,10 @@ case class Year(digits: Int, nMissingDigits: Int = 0) extends Interval {
   */
 case class YearSuffix(interval: Interval, lastDigits: Int, nMissingDigits: Int = 0) extends Interval {
   val isDefined: Boolean = interval.isDefined
-  val nSuffixDigits: Int = (math.log10(lastDigits) + 1).toInt
+  val nSuffixDigits: Int = lastDigits match {
+    case 0 => 1
+    case _ => (math.log10(lastDigits) + 1).toInt
+  }
   val divider: Int = math.pow(10, nSuffixDigits + nMissingDigits).toInt
   val multiplier: Int = math.pow(10, nSuffixDigits).toInt
   lazy val Interval(start, end) = Year(interval.start.getYear / divider * multiplier + lastDigits, nMissingDigits)
@@ -619,8 +622,10 @@ private[formal] object RepeatingInterval {
     case IsoFields.QUARTER_YEARS =>
       ldt.withMonth((ldt.getMonthValue - 1) / 4 + 1).withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS)
     case ChronoUnit.MONTHS => ldt.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS)
-    case ChronoUnit.WEEKS =>
-      ldt.withDayOfYear(ldt.getDayOfYear - ldt.getDayOfWeek.getValue + 1).truncatedTo(ChronoUnit.DAYS)
+    case ChronoUnit.WEEKS => ldt.getDayOfYear - ldt.getDayOfWeek.getValue compare 0 match {
+      case -1 => ldt.withDayOfYear(1).truncatedTo(ChronoUnit.DAYS)
+      case _ => ldt.withDayOfYear(ldt.getDayOfYear - ldt.getDayOfWeek.getValue + 1).truncatedTo(ChronoUnit.DAYS)
+    }
     case range: MonthDayPartialRange => ldt.`with`(range.first).truncatedTo(ChronoUnit.DAYS)
     case range: ConstantPartialRange => ldt.`with`(range.field, range.first).truncatedTo(range.field.getBaseUnit)
     case _ => ldt.truncatedTo(tUnit)


### PR DESCRIPTION
- Some numbers in the clincal data have the format "1-2" and produce match errors. I have added an exception when the number does not have a numeric format. 

- When a two digit year is equal to 00,  YearSuffix produces a division by 0 error. I have tried to handle this.

- If dayoftheyear - dayofthweek is less than 0 the truncation produces invalid values for dayofyear. If that happens I truncate to the day 1 of the year.