### PR TITLE
Adds character spans to all time operators

### DIFF
--- a/src/main/scala/org/clulab/timenorm/formal/Readers.scala
+++ b/src/main/scala/org/clulab/timenorm/formal/Readers.scala
@@ -42,7 +42,7 @@ class AnaforaReader(val DCT: Interval)(implicit data: Data) {
 
 
   def number(entity: Entity)(implicit data: Data): Number = entity.properties("Value") match {
-    case "?" => VagueNumber(entity.text.getOrElse(""))
+    case "?" => VagueNumber(entity.text.getOrElse(""), Some(entity.fullSpan))
     case value =>
       if (value.contains(".")) {
         val (beforeDot, dotAndAfter) = value.span(_ != '.')
@@ -50,11 +50,11 @@ class AnaforaReader(val DCT: Interval)(implicit data: Data) {
         val numerator = dotAndAfter.tail.toInt
         val denominator = math.pow(10, dotAndAfter.length - 1).toInt
         val g = gcd(numerator, denominator)
-        FractionalNumber(number, numerator / g, denominator / g)
+        FractionalNumber(number, numerator / g, denominator / g, Some(entity.fullSpan))
       } else if (value.forall(_.isDigit)) {
-        IntNumber(value.toInt)
+        IntNumber(value.toInt, Some(entity.fullSpan))
       } else {
-        VagueNumber(value)
+        VagueNumber(value, Some(entity.fullSpan))
       }
   }
 
@@ -64,26 +64,23 @@ class AnaforaReader(val DCT: Interval)(implicit data: Data) {
   def integer(entityOption: Option[Entity])(implicit data: Data): Int = entityOption match {
     case None => 1
     case Some(entity) => number(entity) match {
-      case IntNumber(number) => number
+      case IntNumber(number, _) => number
       case _ => throw new AnaforaReader.Exception(
         s"""cannot parse integer from "${entity.text}" and ${entity.entityDescendants.map(_.xml)}""")
     }
   }
 
   def modifier(entity: Entity)(implicit data: Data): Modifier = entity.properties("Type") match {
-    case "Approx" => Modifier.Approx
-    case "Less-Than" => Modifier.LessThan
-    case "More-Than" => Modifier.MoreThan
-    case "Start" => Modifier.Start
-    case "Mid" => Modifier.Mid
-    case "End" => Modifier.End
-    case "Fiscal" => Modifier.Fiscal
+    case "Approx" => Modifier.Approx(Some(entity.fullSpan))
+    case "Less-Than" => Modifier.LessThan(Some(entity.fullSpan))
+    case "More-Than" => Modifier.MoreThan(Some(entity.fullSpan))
+    case "Start" => Modifier.Start(Some(entity.fullSpan))
+    case "Mid" => Modifier.Mid(Some(entity.fullSpan))
+    case "End" => Modifier.End(Some(entity.fullSpan))
+    case "Fiscal" => Modifier.Fiscal(Some(entity.fullSpan))
   }
 
-  def modifier(properties: Properties)(implicit data: Data): Modifier = properties.getEntity("Modifier") match {
-    case None => Modifier.Exact
-    case Some(modifierEntity) => modifier(modifierEntity)
-  }
+  def modifier(properties: Properties)(implicit data: Data): Option[Modifier] = properties.getEntity("Modifier").map(modifier)
 
   def period(entity: Entity)(implicit data: Data): Period = {
     val mod = modifier(entity.properties)
@@ -92,15 +89,15 @@ class AnaforaReader(val DCT: Interval)(implicit data: Data) {
         case "Unknown" =>
           assert(!entity.properties.has("Number"), s"expected empty Number, found ${entity.xml}")
           assert(!entity.properties.has("Modifier"), s"expected empty Modifier, found ${entity.xml}")
-          UnknownPeriod
+          UnknownPeriod(Some(entity.fullSpan))
         case AnaforaReader.SomeChronoUnit(unit) =>
           val n: Number = entity.properties.getEntity("Number") match {
             case Some(numberEntity) => number(numberEntity)
-            case None => if (entity.text.last != 's') IntNumber(1) else VagueNumber("2+")
+            case None => if (entity.text.exists(_.last == 's')) VagueNumber("2+") else IntNumber(1)
           }
-          SimplePeriod(unit, n, mod)
+          SimplePeriod(unit, n, mod, Some(entity.fullSpan))
       }
-      case "Sum" => SumP(entity.properties.getEntities("Periods").map(period).toSet, mod)
+      case "Sum" => SumP(entity.properties.getEntities("Periods").map(period).toSet, mod, Some(entity.fullSpan))
     }
   }
 
@@ -117,7 +114,7 @@ class AnaforaReader(val DCT: Interval)(implicit data: Data) {
       case "DocTime" => DCT
       case "DocTime-Year" => SimpleInterval.of(DCT.start.getYear)
       case "DocTime-Era" => SimpleInterval(LocalDateTime.of(0, 1, 1, 0, 0), LocalDateTime.MAX)
-      case "Unknown" => UnknownInterval
+      case "Unknown" => UnknownInterval()
     }
 
   def interval(entity: Entity)(implicit data: Data): Interval = {
@@ -134,44 +131,49 @@ class AnaforaReader(val DCT: Interval)(implicit data: Data) {
     val N = Seq()
     val Exc = Some("Interval-Not-Included")
     val Inc = Some("Interval-Included")
+    val charSpan = Some(entity.fullSpan)
 
     val result = (entity.`type`, valueOption, periods, repeatingIntervals, numbers, semantics) match {
-      case ("Event", None, N, N, N, None) => Event(entity.text.getOrElse(""))
+      case ("Event", None, N, N, N, None) => Event(entity.text.getOrElse(""), charSpan)
       case ("Year", Some(value), N, N, N, None) => value.partition(_ != '?') match {
-        case (year, questionMarks) => Year(year.toInt, questionMarks.length)
+        case (year, questionMarks) => Year(year.toInt, questionMarks.length, charSpan)
       }
       case ("Two-Digit-Year", Some(value), N, N, N, None) => value.partition(_ != '?') match {
-        case (year, questionMarks) => YearSuffix(interval(properties), year.toInt, year.length, questionMarks.length)
+        case (year, questionMarks) => YearSuffix(interval(properties), year.toInt, year.length, questionMarks.length, charSpan)
       }
-      case ("Between", None, N, N, N, None) => Between(interval(properties, "Start-"), interval(properties, "End-"),
-                                                        included(properties.get("Start-Included")), included(properties.get("End-Included")))
-      case ("This", None, N, N, N, None) => ThisP(interval(properties), UnknownPeriod)
-      case ("This", None, Seq(period), N, N, None) => ThisP(interval(properties), period)
-      case ("This", None, N, Seq(rInterval), N, None) => ThisRI(interval(properties), rInterval)
-      case ("Last", None, N, N, N, _) => LastP(interval(properties), UnknownPeriod)
-      case ("Last", None, Seq(period), N, N, _) => LastP(interval(properties), period)
-      case ("Last", None, N, Seq(rInterval), N, Exc) => LastRI(interval(properties), rInterval)
-      case ("Last", None, N, Seq(rInterval), N, Inc) => LastRI(interval(properties), rInterval, from = Interval.End)
-      case ("Next", None, N, N, N, _) => NextP(interval(properties), UnknownPeriod)
-      case ("Next", None, Seq(period), N, N, _) => NextP(interval(properties), period)
-      case ("Next", None, N, Seq(rInterval), N, Exc) => NextRI(interval(properties), rInterval)
-      case ("Next", None, N, Seq(rInterval), N, Inc) => NextRI(interval(properties), rInterval, from = Interval.Start)
-      case ("Before", None, N, N, N, _) => BeforeP(interval(properties), UnknownPeriod)
-      case ("Before", None, Seq(period), N, N, _) => BeforeP(interval(properties), period)
-      case ("Before", None, N, Seq(rInterval), N, Exc) => BeforeRI(interval(properties), rInterval)
-      case ("Before", None, N, Seq(rInterval), N, Inc) => BeforeRI(interval(properties), rInterval, from = Interval.End)
-      case ("Before", None, N, Seq(rInterval), Seq(number), Exc) => BeforeRI(interval(properties), rInterval, number)
-      case ("Before", None, N, Seq(rInterval), Seq(number), Inc) => BeforeRI(interval(properties), rInterval, number, from = Interval.End)
-      case ("After", None, N, N, N, _) => AfterP(interval(properties), UnknownPeriod)
-      case ("After", None, Seq(period), N, N, _) => AfterP(interval(properties), period)
-      case ("After", None, N, Seq(rInterval), N, Exc) => AfterRI(interval(properties), rInterval)
-      case ("After", None, N, Seq(rInterval), N, Inc) => AfterRI(interval(properties), rInterval, from = Interval.Start)
-      case ("After", None, N, Seq(rInterval), Seq(number), Exc) => AfterRI(interval(properties), rInterval, number)
-      case ("After", None, N, Seq(rInterval), Seq(number), Inc) => AfterRI(interval(properties), rInterval, number, from = Interval.Start)
-      case ("NthFromStart", Some(value), N, N, N, None) => NthP(interval(properties), value.toInt, UnknownPeriod)
-      case ("NthFromStart", Some(value), Seq(period), N, N, None) => NthP(interval(properties), value.toInt, period)
-      case ("NthFromStart", Some(value), N, Seq(rInterval), N, None) => NthRI(interval(properties), value.toInt, rInterval)
-      case ("Intersection", None, N, N, N, None) => IntersectionI(entity.properties.getEntities("Intervals").map(interval))
+      case ("Between", None, N, N, N, None) => Between(
+        interval(properties, "Start-"),
+        interval(properties, "End-"),
+        included(properties.get("Start-Included")),
+        included(properties.get("End-Included")),
+        charSpan)
+      case ("This", None, N, N, N, None) => ThisP(interval(properties), UnknownPeriod(), charSpan)
+      case ("This", None, Seq(period), N, N, None) => ThisP(interval(properties), period, charSpan)
+      case ("This", None, N, Seq(rInterval), N, None) => ThisRI(interval(properties), rInterval, charSpan)
+      case ("Last", None, N, N, N, _) => LastP(interval(properties), UnknownPeriod(), charSpan)
+      case ("Last", None, Seq(period), N, N, _) => LastP(interval(properties), period, charSpan)
+      case ("Last", None, N, Seq(rInterval), N, Exc) => LastRI(interval(properties), rInterval, triggerCharSpan = charSpan)
+      case ("Last", None, N, Seq(rInterval), N, Inc) => LastRI(interval(properties), rInterval, from = Interval.End, triggerCharSpan = charSpan)
+      case ("Next", None, N, N, N, _) => NextP(interval(properties), UnknownPeriod(), charSpan)
+      case ("Next", None, Seq(period), N, N, _) => NextP(interval(properties), period, charSpan)
+      case ("Next", None, N, Seq(rInterval), N, Exc) => NextRI(interval(properties), rInterval, triggerCharSpan = charSpan)
+      case ("Next", None, N, Seq(rInterval), N, Inc) => NextRI(interval(properties), rInterval, from = Interval.Start, triggerCharSpan = charSpan)
+      case ("Before", None, N, N, N, _) => BeforeP(interval(properties), UnknownPeriod(), charSpan)
+      case ("Before", None, Seq(period), N, N, _) => BeforeP(interval(properties), period, charSpan)
+      case ("Before", None, N, Seq(rInterval), N, Exc) => BeforeRI(interval(properties), rInterval, triggerCharSpan = charSpan)
+      case ("Before", None, N, Seq(rInterval), N, Inc) => BeforeRI(interval(properties), rInterval, from = Interval.End, triggerCharSpan = charSpan)
+      case ("Before", None, N, Seq(rInterval), Seq(number), Exc) => BeforeRI(interval(properties), rInterval, number, triggerCharSpan = charSpan)
+      case ("Before", None, N, Seq(rInterval), Seq(number), Inc) => BeforeRI(interval(properties), rInterval, number, from = Interval.End, triggerCharSpan = charSpan)
+      case ("After", None, N, N, N, _) => AfterP(interval(properties), UnknownPeriod(), charSpan)
+      case ("After", None, Seq(period), N, N, _) => AfterP(interval(properties), period, charSpan)
+      case ("After", None, N, Seq(rInterval), N, Exc) => AfterRI(interval(properties), rInterval, triggerCharSpan = charSpan)
+      case ("After", None, N, Seq(rInterval), N, Inc) => AfterRI(interval(properties), rInterval, from = Interval.Start, triggerCharSpan = charSpan)
+      case ("After", None, N, Seq(rInterval), Seq(number), Exc) => AfterRI(interval(properties), rInterval, number, triggerCharSpan = charSpan)
+      case ("After", None, N, Seq(rInterval), Seq(number), Inc) => AfterRI(interval(properties), rInterval, number, from = Interval.Start, triggerCharSpan = charSpan)
+      case ("NthFromStart", Some(value), N, N, N, None) => NthP(interval(properties), value.toInt, UnknownPeriod(), triggerCharSpan = charSpan)
+      case ("NthFromStart", Some(value), Seq(period), N, N, None) => NthP(interval(properties), value.toInt, period, triggerCharSpan = charSpan)
+      case ("NthFromStart", Some(value), N, Seq(rInterval), N, None) => NthRI(interval(properties), value.toInt, rInterval, triggerCharSpan = charSpan)
+      case ("Intersection", None, N, N, N, None) => IntersectionI(entity.properties.getEntities("Intervals").map(interval), charSpan)
       case _ => throw new AnaforaReader.Exception(
         s"""cannot parse Interval from "${entity.text}" and ${entity.entityDescendants.map(_.xml)}""")
     }
@@ -193,14 +195,15 @@ class AnaforaReader(val DCT: Interval)(implicit data: Data) {
     val intervalEntities = entity.properties.getEntities("Intervals")
     val intervals = intervalEntities.map(interval)
     val N = Seq()
+    val charSpan = Some(entity.fullSpan)
 
     (entity.`type`, valueOption, periods, repeatingIntervals, numbers, intervals) match {
-      case ("Intersection", None, N, Seq(repeatingInterval), N, Seq(interval)) => ThisRIs(interval, repeatingInterval)
-      case ("Intersection", None, N, ris, N, Seq(interval)) => ThisRIs(interval, IntersectionRI(ris.toSet))
-      case ("Last", None, N, Seq(rInterval), Seq(number), N) => LastRIs(interval(entity.properties), rInterval, number)
-      case ("Next", None, N, Seq(rInterval), Seq(number), N) => NextRIs(interval(entity.properties), rInterval, number)
+      case ("Intersection", None, N, Seq(repeatingInterval), N, Seq(interval)) => ThisRIs(interval, repeatingInterval, charSpan)
+      case ("Intersection", None, N, ris, N, Seq(interval)) => ThisRIs(interval, IntersectionRI(ris.toSet), charSpan)
+      case ("Last", None, N, Seq(rInterval), Seq(number), N) => LastRIs(interval(entity.properties), rInterval, number, triggerCharSpan = charSpan)
+      case ("Next", None, N, Seq(rInterval), Seq(number), N) => NextRIs(interval(entity.properties), rInterval, number, triggerCharSpan = charSpan)
       case ("NthFromStart", Some(value), N, Seq(rInterval), Seq(number), N) =>
-        NthRIs(interval(entity.properties), value.toInt, rInterval, number)
+        NthRIs(interval(entity.properties), value.toInt, rInterval, number, triggerCharSpan = charSpan)
       case _ => throw new AnaforaReader.Exception(
         s"""cannot parse Intervals from "${entity.text}" and ${entity.entityDescendants.map(_.xml)}""")
     }
@@ -208,42 +211,43 @@ class AnaforaReader(val DCT: Interval)(implicit data: Data) {
 
   def repeatingInterval(entity: Entity)(implicit data: Data): RepeatingInterval = {
     val mod = modifier(entity.properties)
+    val charSpan = Some(entity.fullSpan)
     val result = (entity.`type`, entity.properties.get("Type")) match {
       case ("Union", None) =>
         val repeatingIntervalEntities = entity.properties.getEntities("Repeating-Intervals")
-        UnionRI(repeatingIntervalEntities.map(repeatingInterval).toSet)
+        UnionRI(repeatingIntervalEntities.map(repeatingInterval).toSet, charSpan)
       case ("Intersection", None) =>
         val repeatingIntervals = entity.properties.getEntities("Repeating-Intervals").map(repeatingInterval)
         if (entity.properties.has("Intervals")) throw new AnaforaReader.Exception(
           s"""cannot parse Intersection from "${entity.text}" and ${entity.entityDescendants.map(_.xml)}""")
-        IntersectionRI(repeatingIntervals.toSet)
-      case ("Calendar-Interval" , Some("Century")) => RepeatingUnit(ChronoUnit.CENTURIES, mod)
-      case ("Calendar-Interval" , Some("Quarter-Century")) => RepeatingUnit(QUARTER_CENTURIES, mod)
-      case ("Calendar-Interval" , Some("Quarter-Year")) => RepeatingUnit(IsoFields.QUARTER_YEARS, mod)
-      case ("Calendar-Interval" , Some(AnaforaReader.SomePluralChronoUnit(unit))) => RepeatingUnit(unit, mod)
-      case ("Week-Of-Year", None) => RepeatingField(WeekFields.ISO.weekOfYear(), entity.properties("Value").toLong, mod)
-      case ("Season-Of-Year", Some("Spring")) => RepeatingField(SPRING_OF_YEAR, 1L, mod)
-      case ("Season-Of-Year", Some("Summer")) => RepeatingField(SUMMER_OF_YEAR, 1L, mod)
-      case ("Season-Of-Year", Some("Fall")) => RepeatingField(FALL_OF_YEAR, 1L, mod)
-      case ("Season-Of-Year", Some("Winter")) => RepeatingField(WINTER_OF_YEAR, 1L, mod)
-      case ("Part-Of-Week", Some("Weekend")) => RepeatingField(WEEKEND_OF_WEEK, 1, mod)
-      case ("Part-Of-Week", Some("Weekdays")) => RepeatingField(WEEKEND_OF_WEEK, 0, mod)
-      case ("Part-Of-Day", Some("Dawn")) => RepeatingField(ChronoField.SECOND_OF_DAY, 5L * 60L * 60L, Modifier.Approx)
-      case ("Part-Of-Day", Some("Morning")) => RepeatingField(MORNING_OF_DAY, 1, mod)
-      case ("Part-Of-Day", Some("Noon")) => RepeatingField(ChronoField.MINUTE_OF_DAY, 12L * 60L, mod)
-      case ("Part-Of-Day", Some("Afternoon")) => RepeatingField(AFTERNOON_OF_DAY, 1, mod)
-      case ("Part-Of-Day", Some("Evening")) => RepeatingField(EVENING_OF_DAY, 1, mod)
-      case ("Part-Of-Day", Some("Dusk")) => RepeatingField(ChronoField.SECOND_OF_DAY, 19L * 60L * 60L, Modifier.Approx)
-      case ("Part-Of-Day", Some("Night")) => RepeatingField(NIGHT_OF_DAY, 1, mod)
-      case ("Part-Of-Day", Some("Midnight")) => RepeatingField(ChronoField.SECOND_OF_DAY, 0L, mod)
+        IntersectionRI(repeatingIntervals.toSet, charSpan)
+      case ("Calendar-Interval" , Some("Century")) => RepeatingUnit(ChronoUnit.CENTURIES, mod, charSpan)
+      case ("Calendar-Interval" , Some("Quarter-Century")) => RepeatingUnit(QUARTER_CENTURIES, mod, charSpan)
+      case ("Calendar-Interval" , Some("Quarter-Year")) => RepeatingUnit(IsoFields.QUARTER_YEARS, mod, charSpan)
+      case ("Calendar-Interval" , Some(AnaforaReader.SomePluralChronoUnit(unit))) => RepeatingUnit(unit, mod, charSpan)
+      case ("Week-Of-Year", None) => RepeatingField(WeekFields.ISO.weekOfYear(), entity.properties("Value").toLong, mod, charSpan)
+      case ("Season-Of-Year", Some("Spring")) => RepeatingField(SPRING_OF_YEAR, 1L, mod, charSpan)
+      case ("Season-Of-Year", Some("Summer")) => RepeatingField(SUMMER_OF_YEAR, 1L, mod, charSpan)
+      case ("Season-Of-Year", Some("Fall")) => RepeatingField(FALL_OF_YEAR, 1L, mod, charSpan)
+      case ("Season-Of-Year", Some("Winter")) => RepeatingField(WINTER_OF_YEAR, 1L, mod, charSpan)
+      case ("Part-Of-Week", Some("Weekend")) => RepeatingField(WEEKEND_OF_WEEK, 1, mod, charSpan)
+      case ("Part-Of-Week", Some("Weekdays")) => RepeatingField(WEEKEND_OF_WEEK, 0, mod, charSpan)
+      case ("Part-Of-Day", Some("Dawn")) => RepeatingField(ChronoField.SECOND_OF_DAY, 5L * 60L * 60L, Some(Modifier.Approx()), charSpan)
+      case ("Part-Of-Day", Some("Morning")) => RepeatingField(MORNING_OF_DAY, 1, mod, charSpan)
+      case ("Part-Of-Day", Some("Noon")) => RepeatingField(ChronoField.MINUTE_OF_DAY, 12L * 60L, mod, charSpan)
+      case ("Part-Of-Day", Some("Afternoon")) => RepeatingField(AFTERNOON_OF_DAY, 1, mod, charSpan)
+      case ("Part-Of-Day", Some("Evening")) => RepeatingField(EVENING_OF_DAY, 1, mod, charSpan)
+      case ("Part-Of-Day", Some("Dusk")) => RepeatingField(ChronoField.SECOND_OF_DAY, 19L * 60L * 60L, Some(Modifier.Approx()), charSpan)
+      case ("Part-Of-Day", Some("Night")) => RepeatingField(NIGHT_OF_DAY, 1, mod, charSpan)
+      case ("Part-Of-Day", Some("Midnight")) => RepeatingField(ChronoField.SECOND_OF_DAY, 0L, mod, charSpan)
       case ("Hour-Of-Day", None) =>
         // TODO: handle time zone
         val value = entity.properties("Value").toLong
         entity.properties.getEntity("AMPM-Of-Day") match {
           case Some(ampmEntity) => IntersectionRI(Set(
-            RepeatingField(ChronoField.CLOCK_HOUR_OF_AMPM, value, mod),
+            RepeatingField(ChronoField.CLOCK_HOUR_OF_AMPM, value, mod, charSpan),
             repeatingInterval(ampmEntity)))
-          case None => RepeatingField(ChronoField.CLOCK_HOUR_OF_DAY, value, mod)
+          case None => RepeatingField(ChronoField.CLOCK_HOUR_OF_DAY, value, mod, charSpan)
         }
       case (AnaforaReader.SomeChronoField(field), _) =>
         val value: Long = field match {
@@ -258,23 +262,23 @@ class AnaforaReader(val DCT: Interval)(implicit data: Data) {
           case _ => throw new AnaforaReader.Exception(
             s"""cannot parse ChronoField value from "${entity.text}" and ${entity.entityDescendants.map(_.xml)}""")
         }
-        RepeatingField(field, value, mod)
+        RepeatingField(field, value, mod, charSpan)
       case _ => throw new AnaforaReader.Exception(
         s"""cannot parse RepeatingInterval from "${entity.text}" and ${entity.entityDescendants.map(_.xml)}""")
     }
     flatten(entity.properties.getEntities("Sub-Interval") match {
       case Seq() => result
       //case subEntities => IntersectionRI(Set(result) ++ subEntities.map(repeatingInterval))
-      case subEntities => IntersectionRI(Set(result) ++ Set(repeatingInterval(subEntities.head))) // Only take the first SubInterval. If there are more than one the should be equivalent.
+      case subEntities => IntersectionRI(Set(result) ++ Set(repeatingInterval(subEntities.head))) // Only take the first SubInterval. If there are more than one they should be equivalent.
 
     })
   }
 
   def flatten(repeatingInterval: RepeatingInterval): RepeatingInterval = repeatingInterval match {
-    case IntersectionRI(repeatingIntervals) => IntersectionRI(repeatingIntervals.flatMap {
-      case IntersectionRI(subIntervals) => subIntervals.map(flatten)
+    case IntersectionRI(repeatingIntervals, charSpan) => IntersectionRI(repeatingIntervals.flatMap {
+      case IntersectionRI(subIntervals, _) => subIntervals.map(flatten)
       case rIntervals => Set(rIntervals)
-    })
+    }, charSpan)
     case other => other
   }
 

--- a/src/main/scala/org/clulab/timenorm/formal/Types.scala
+++ b/src/main/scala/org/clulab/timenorm/formal/Types.scala
@@ -555,7 +555,7 @@ case class Between(startInterval: Interval,
                    endIncluded: Boolean = false,
                    triggerCharSpan: Option[(Int, Int)] = None) extends Interval {
   val isDefined: Boolean = startInterval.isDefined && endInterval.isDefined
-  val charSpan: Option[(Int, Int)] = maxSpan(Seq(startInterval.charSpan, endInterval.charSpan))
+  val charSpan: Option[(Int, Int)] = maxSpan(Seq(startInterval.charSpan, endInterval.charSpan, triggerCharSpan))
   lazy val start: LocalDateTime = if (startIncluded) startInterval.start else startInterval.end
   lazy val end: LocalDateTime = if (endIncluded) endInterval.end else endInterval.start
 }

--- a/src/main/scala/org/clulab/timenorm/formal/Types.scala
+++ b/src/main/scala/org/clulab/timenorm/formal/Types.scala
@@ -10,6 +10,13 @@ import scala.util.{Success, Try}
 
 trait TimeExpression {
   def isDefined: Boolean
+  def charSpan: Option[(Int, Int)]
+
+  private[formal] def maxSpan(spanOptions: Seq[Option[(Int, Int)]]): Option[(Int, Int)] =
+    spanOptions.flatten.sorted match {
+      case Seq() => None
+      case spans => Some((spans.head._1, spans.last._2))
+    }
 }
 
 trait Number extends TimeExpression
@@ -21,15 +28,18 @@ object Number {
   implicit def intToNumber(n: Int): Number = IntNumber(n)
 }
 
-case class IntNumber(n: Int) extends Number {
+case class IntNumber(n: Int, charSpan: Option[(Int, Int)] = None) extends Number {
   val isDefined = true
 }
 
-case class FractionalNumber(number: Int, numerator: Int, denominator: Int) extends Number {
+case class FractionalNumber(number: Int,
+                            numerator: Int,
+                            denominator: Int,
+                            charSpan: Option[(Int, Int)] = None) extends Number {
   val isDefined = true
 }
 
-case class VagueNumber(description: String) extends Number {
+case class VagueNumber(description: String, charSpan: Option[(Int, Int)] = None) extends Number {
   val isDefined = false
 }
 
@@ -39,21 +49,21 @@ trait Modifier extends TimeExpression {
 
 object Modifier {
 
-  case object Exact extends Modifier
+  case class Exact(charSpan: Option[(Int, Int)] = None) extends Modifier
 
-  case object Approx extends Modifier
+  case class Approx(charSpan: Option[(Int, Int)] = None) extends Modifier
 
-  case object LessThan extends Modifier
+  case class LessThan(charSpan: Option[(Int, Int)] = None) extends Modifier
 
-  case object MoreThan extends Modifier
+  case class MoreThan(charSpan: Option[(Int, Int)] = None) extends Modifier
 
-  case object Start extends Modifier
+  case class Start(charSpan: Option[(Int, Int)] = None) extends Modifier
 
-  case object Mid extends Modifier
+  case class Mid(charSpan: Option[(Int, Int)] = None) extends Modifier
 
-  case object End extends Modifier
+  case class End(charSpan: Option[(Int, Int)] = None) extends Modifier
 
-  case object Fiscal extends Modifier
+  case class Fiscal(charSpan: Option[(Int, Int)] = None) extends Modifier
 
 }
 
@@ -65,11 +75,15 @@ object Modifier {
   */
 trait Period extends TimeExpression with TemporalAmount
 
-case class SimplePeriod(unit: TemporalUnit, n: Number, modifier: Modifier = Modifier.Exact) extends Period {
+case class SimplePeriod(unit: TemporalUnit,
+                        n: Number,
+                        modifier: Option[Modifier] = None,
+                        targetCharSpan: Option[(Int, Int)] = None) extends Period {
 
-  val isDefined: Boolean = n.isDefined && modifier == Modifier.Exact
+  val isDefined: Boolean = n.isDefined && modifier.forall(_.isInstanceOf[Modifier.Exact])
+  val charSpan: Option[(Int, Int)] = maxSpan(Seq(n.charSpan, modifier.flatMap(_.charSpan), targetCharSpan))
 
-  lazy val IntNumber(number) = n
+  lazy val IntNumber(number, _) = n
 
   override def addTo(temporal: Temporal): Temporal = temporal.plus(number, unit)
 
@@ -85,7 +99,7 @@ case class SimplePeriod(unit: TemporalUnit, n: Number, modifier: Modifier = Modi
   override def getUnits: java.util.List[TemporalUnit] = java.util.Collections.singletonList(unit)
 }
 
-case object UnknownPeriod extends Period {
+case class UnknownPeriod(charSpan: Option[(Int, Int)] = None) extends Period {
   val isDefined = false
 
   override def addTo(temporal: Temporal): Temporal = throw new UnsupportedOperationException
@@ -97,9 +111,12 @@ case object UnknownPeriod extends Period {
   override def getUnits: java.util.List[TemporalUnit] = throw new UnsupportedOperationException
 }
 
-case class SumP(periods: Set[Period], modifier: Modifier = Modifier.Exact) extends Period {
+case class SumP(periods: Set[Period],
+                modifier: Option[Modifier] = None,
+                targetCharSpan: Option[(Int, Int)] = None) extends Period {
 
-  val isDefined: Boolean = periods.forall(_.isDefined) && modifier == Modifier.Exact
+  val isDefined: Boolean = periods.forall(_.isDefined) && modifier.forall(_.isInstanceOf[Modifier.Exact])
+  val charSpan: Option[(Int, Int)] = maxSpan(Seq(modifier.flatMap(_.charSpan), targetCharSpan))
 
   lazy val map: Map[TemporalUnit, Long] = Map.empty ++ periods.flatMap(_.getUnits.asScala).map {
     unit => (unit, periods.filter(_.getUnits.contains(unit)).map(_.get(unit)).sum)
@@ -145,7 +162,6 @@ object Interval {
   case object End extends Point {
     override def apply(interval: Interval): LocalDateTime = interval.end
   }
-
 }
 
 trait Intervals extends TimeExpression with Seq[Interval] {
@@ -160,9 +176,10 @@ trait Intervals extends TimeExpression with Seq[Interval] {
 
 case class SimpleIntervals(intervals: Seq[Interval]) extends Intervals {
   val isDefined = true
+  val charSpan: Option[(Int, Int)] = maxSpan(intervals.map(_.charSpan))
 }
 
-case object UnknownInterval extends Interval {
+case class UnknownInterval(charSpan: Option[(Int, Int)] = None) extends Interval {
   val isDefined = false
 
   def start: LocalDateTime = throw new UnsupportedOperationException
@@ -170,7 +187,7 @@ case object UnknownInterval extends Interval {
   def end: LocalDateTime = throw new UnsupportedOperationException
 }
 
-case class Event(description: String) extends Interval {
+case class Event(description: String, charSpan: Option[(Int, Int)] = None) extends Interval {
   val isDefined = false
 
   def start: LocalDateTime = throw new UnsupportedOperationException
@@ -180,6 +197,7 @@ case class Event(description: String) extends Interval {
 
 case class SimpleInterval(start: LocalDateTime, end: LocalDateTime) extends Interval {
   val isDefined = true
+  val charSpan: Option[(Int, Int)] = None
 }
 
 object SimpleInterval {
@@ -219,7 +237,7 @@ object SimpleInterval {
   * next year (exclusive). The optional second parameter allows this to also represent decades (nMissingDigits=1),
   * centuries (nMissingDigits=2), etc.
   */
-case class Year(digits: Int, nMissingDigits: Int = 0) extends Interval {
+case class Year(digits: Int, nMissingDigits: Int = 0, charSpan: Option[(Int, Int)] = None) extends Interval {
   val isDefined = true
   private val durationInYears = math.pow(10, nMissingDigits).toInt
   lazy val start: LocalDateTime = LocalDateTime.of(digits * durationInYears, 1, 1, 0, 0, 0, 0)
@@ -231,7 +249,12 @@ case class Year(digits: Int, nMissingDigits: Int = 0) extends Interval {
   * As with Year, the optional second parameter allows YearSuffix to represent decades (nMissingDigits=1),
   * centuries (nMissingDigits=2), etc.
   */
-case class YearSuffix(interval: Interval, lastDigits: Int, nSuffixDigits: Int, nMissingDigits: Int = 0) extends Interval {
+case class YearSuffix(interval: Interval,
+                      lastDigits: Int,
+                      nSuffixDigits: Int,
+                      nMissingDigits: Int = 0,
+                      triggerCharSpan: Option[(Int, Int)] = None) extends Interval {
+  val charSpan: Option[(Int, Int)] = maxSpan(Seq(interval.charSpan, triggerCharSpan))
   val isDefined: Boolean = interval.isDefined
   val divider: Int = math.pow(10, nSuffixDigits + nMissingDigits).toInt
   val multiplier: Int = math.pow(10, nSuffixDigits).toInt
@@ -256,20 +279,34 @@ private[timenorm] object PeriodUtil {
 }
 
 /**
+  * Base trait for time expressions that take Interval and Period arguments
+  */
+trait IP extends TimeExpression {
+  val interval: Interval
+  val period: Period
+  val triggerCharSpan: Option[(Int, Int)]
+  lazy val isDefined: Boolean = interval.isDefined && period.isDefined
+  lazy val charSpan: Option[(Int, Int)] = maxSpan(Seq(interval.charSpan, period.charSpan, triggerCharSpan))
+}
+
+/**
   * Creates an interval of a given Period length centered on a given interval. Formally:
   * This([t1,t2): Interval, Δ: Period) = [ (t1 + t2)/2 - Δ/2, (t1 + t2)/2 + Δ/2 )
   *
   * @param interval interval to center the period upon
   * @param period   period of interest
   */
-case class ThisP(interval: Interval, period: Period) extends Interval {
-  val isDefined: Boolean = interval.isDefined && period.isDefined
+case class ThisP(interval: Interval,
+                 period: Period,
+                 triggerCharSpan: Option[(Int, Int)] = None) extends Interval with IP {
   lazy val Interval(start, end) = PeriodUtil.expand(interval, period)
 }
 
 trait This extends TimeExpression {
   val interval: Interval
   val repeatingInterval: RepeatingInterval
+  val triggerCharSpan: Option[(Int, Int)]
+  lazy val charSpan: Option[(Int, Int)] = maxSpan(Seq(interval.charSpan, repeatingInterval.charSpan, triggerCharSpan))
   lazy val intervals: Seq[Interval] = {
     // find a start that aligns to the start of the repeating interval's range unit
     val rangeStart = RepeatingInterval.truncate(interval.start, repeatingInterval.range)
@@ -293,7 +330,9 @@ trait This extends TimeExpression {
   * @param interval          the interval identifying the boundaries of the container
   * @param repeatingInterval the repeating intervals that should be found within the container
   */
-case class ThisRI(interval: Interval, repeatingInterval: RepeatingInterval) extends Interval with This {
+case class ThisRI(interval: Interval,
+                  repeatingInterval: RepeatingInterval,
+                  triggerCharSpan: Option[(Int, Int)] = None) extends Interval with This {
   lazy val Seq(Interval(start, end)) = intervals
 }
 
@@ -305,8 +344,9 @@ case class ThisRI(interval: Interval, repeatingInterval: RepeatingInterval) exte
   * @param interval          the interval identifying the boundaries of the container
   * @param repeatingInterval the repeating intervals that should be found within the container
   */
-case class ThisRIs(interval: Interval, repeatingInterval: RepeatingInterval)
-  extends Intervals with This {
+case class ThisRIs(interval: Interval,
+                   repeatingInterval: RepeatingInterval,
+                   triggerCharSpan: Option[(Int, Int)] = None) extends Intervals with This {
   // force the case class toString rather than Seq.toString
   override lazy val toString: String = scala.runtime.ScalaRunTime._toString(this)
 }
@@ -318,21 +358,28 @@ case class ThisRIs(interval: Interval, repeatingInterval: RepeatingInterval)
   * @param interval interval to shift from
   * @param period   period to shift the interval by
   */
-case class LastP(interval: Interval, period: Period) extends Interval {
-  val isDefined: Boolean = interval.isDefined && period.isDefined
+case class LastP(interval: Interval,
+                 period: Period,
+                 triggerCharSpan: Option[(Int, Int)] = None) extends Interval with IP {
   lazy val start: LocalDateTime = interval.start.minus(period)
   lazy val end: LocalDateTime = interval.start
 }
 
-trait IRIN {
+/**
+  * Base trait for time expressions that take Interval, RepeatingInterval, and Number arguments
+  */
+trait IRIN extends TimeExpression {
   val interval: Interval
   val repeatingInterval: RepeatingInterval
   val number: Number
+  val triggerCharSpan: Option[(Int, Int)]
   lazy val isDefined: Boolean = interval.isDefined && repeatingInterval.isDefined && number.isDefined
-  lazy val IntNumber(integer) = number
+  lazy val charSpan: Option[(Int, Int)] = maxSpan(
+    Seq(interval.charSpan, repeatingInterval.charSpan, number.charSpan, triggerCharSpan))
+  lazy val IntNumber(integer, _) = number
 }
 
-trait Last extends TimeExpression with IRIN {
+trait Last extends IRIN {
   val from: Interval => LocalDateTime
   lazy val intervals: Seq[Interval] = repeatingInterval.preceding(from(interval)).take(integer).toSeq
 }
@@ -346,7 +393,8 @@ trait Last extends TimeExpression with IRIN {
   */
 case class LastRI(interval: Interval,
                   repeatingInterval: RepeatingInterval,
-                  from: Interval.Point = Interval.Start) extends Interval with Last {
+                  from: Interval.Point = Interval.Start,
+                  triggerCharSpan: Option[(Int, Int)] = None) extends Interval with Last {
   val number = IntNumber(1)
   lazy val Seq(Interval(start, end)) = intervals
 }
@@ -362,8 +410,8 @@ case class LastRI(interval: Interval,
 case class LastRIs(interval: Interval,
                    repeatingInterval: RepeatingInterval,
                    number: Number = IntNumber(1),
-                   from: Interval.Point = Interval.Start)
-  extends Intervals with Last {
+                   from: Interval.Point = Interval.Start,
+                   triggerCharSpan: Option[(Int, Int)] = None) extends Intervals with Last {
   // force the case class toString rather than Seq.toString
   override lazy val toString: String = scala.runtime.ScalaRunTime._toString(this)
 }
@@ -375,13 +423,14 @@ case class LastRIs(interval: Interval,
   * @param interval interval to shift from
   * @param period   period to shift the interval by
   */
-case class NextP(interval: Interval, period: Period) extends Interval {
-  val isDefined: Boolean = interval.isDefined && period.isDefined
+case class NextP(interval: Interval,
+                 period: Period,
+                 triggerCharSpan: Option[(Int, Int)] = None) extends Interval with IP {
   lazy val start: LocalDateTime = interval.end
   lazy val end: LocalDateTime = start.plus(period)
 }
 
-trait Next extends TimeExpression with IRIN {
+trait Next extends IRIN {
   val from: Interval => LocalDateTime
   lazy val intervals: Seq[Interval] = repeatingInterval.following(from(interval)).take(integer).toSeq
 }
@@ -395,7 +444,8 @@ trait Next extends TimeExpression with IRIN {
   */
 case class NextRI(interval: Interval,
                   repeatingInterval: RepeatingInterval,
-                  from: Interval.Point = Interval.End) extends Interval with Next {
+                  from: Interval.Point = Interval.End,
+                  triggerCharSpan: Option[(Int, Int)] = None) extends Interval with Next {
   val number = IntNumber(1)
   lazy val Seq(Interval(start, end)) = intervals
 }
@@ -411,7 +461,8 @@ case class NextRI(interval: Interval,
 case class NextRIs(interval: Interval,
                    repeatingInterval: RepeatingInterval,
                    number: Number = IntNumber(1),
-                   from: Interval.Point = Interval.End) extends Intervals with Next {
+                   from: Interval.Point = Interval.End,
+                   triggerCharSpan: Option[(Int, Int)] = None) extends Intervals with Next {
   // force the case class toString rather than Seq.toString
   override lazy val toString: String = scala.runtime.ScalaRunTime._toString(this)
 }
@@ -428,8 +479,9 @@ case class NextRIs(interval: Interval,
   * @param interval interval to shift from
   * @param period   period to shift the interval by
   */
-case class BeforeP(interval: Interval, period: Period) extends Interval {
-  val isDefined: Boolean = interval.isDefined && period.isDefined
+case class BeforeP(interval: Interval,
+                   period: Period,
+                   triggerCharSpan: Option[(Int, Int)] = None) extends Interval with IP {
   lazy val Interval(start, end) = PeriodUtil.expandIfLarger(
     SimpleInterval(interval.start.minus(period), interval.end.minus(period)),
     PeriodUtil.oneUnit(period))
@@ -447,8 +499,8 @@ case class BeforeP(interval: Interval, period: Period) extends Interval {
 case class BeforeRI(interval: Interval,
                     repeatingInterval: RepeatingInterval,
                     number: Number = IntNumber(1),
-                    from: Interval.Point = Interval.Start)
-  extends Interval with IRIN {
+                    from: Interval.Point = Interval.Start,
+                    triggerCharSpan: Option[(Int, Int)] = None) extends Interval with IRIN {
   lazy val Interval(start, end) = repeatingInterval.preceding(from(interval)).drop(integer - 1).next
 }
 
@@ -464,8 +516,9 @@ case class BeforeRI(interval: Interval,
   * @param interval interval to shift from
   * @param period   period to shift the interval by
   */
-case class AfterP(interval: Interval, period: Period) extends Interval {
-  val isDefined: Boolean = interval.isDefined && period.isDefined
+case class AfterP(interval: Interval,
+                  period: Period,
+                  triggerCharSpan: Option[(Int, Int)] = None) extends Interval with IP {
   lazy val Interval(start, end) = PeriodUtil.expandIfLarger(
     SimpleInterval(interval.start.plus(period), interval.end.plus(period)),
     PeriodUtil.oneUnit(period))
@@ -482,7 +535,8 @@ case class AfterP(interval: Interval, period: Period) extends Interval {
 case class AfterRI(interval: Interval,
                    repeatingInterval: RepeatingInterval,
                    number: Number = IntNumber(1),
-                   from: Interval.Point = Interval.End) extends Interval with IRIN {
+                   from: Interval.Point = Interval.End,
+                   triggerCharSpan: Option[(Int, Int)] = None) extends Interval with IRIN {
   lazy val Interval(start, end) = repeatingInterval.following(from(interval)).drop(integer - 1).next
 }
 
@@ -495,16 +549,15 @@ case class AfterRI(interval: Interval,
   * @param startIncluded first interval is included
   * @param endIncluded   second interval is included
   */
-case class Between(startInterval: Interval, endInterval: Interval, startIncluded: Boolean = false, endIncluded: Boolean = false) extends Interval {
+case class Between(startInterval: Interval,
+                   endInterval: Interval,
+                   startIncluded: Boolean = false,
+                   endIncluded: Boolean = false,
+                   triggerCharSpan: Option[(Int, Int)] = None) extends Interval {
   val isDefined: Boolean = startInterval.isDefined && endInterval.isDefined
-  lazy val (start: LocalDateTime) = startIncluded match {
-    case true => startInterval.start
-    case false => startInterval.end
-  }
-  lazy val (end: LocalDateTime) = endIncluded match {
-    case true => endInterval.end
-    case false => endInterval.start
-  }
+  val charSpan: Option[(Int, Int)] = maxSpan(Seq(startInterval.charSpan, endInterval.charSpan))
+  lazy val start: LocalDateTime = if (startIncluded) startInterval.start else startInterval.end
+  lazy val end: LocalDateTime = if (endIncluded) endInterval.end else endInterval.start
 }
 
 /**
@@ -520,8 +573,8 @@ case class Between(startInterval: Interval, endInterval: Interval, startIncluded
 case class NthP(interval: Interval,
                 index: Int,
                 period: Period,
-                from: Interval.Point = Interval.Start) extends Interval {
-  val isDefined: Boolean = interval.isDefined && period.isDefined
+                from: Interval.Point = Interval.Start,
+                triggerCharSpan: Option[(Int, Int)] = None) extends Interval with IP {
   lazy val Interval(start, end) = {
     val periods = Iterator.fill(index - 1)(period)
     from match {
@@ -561,8 +614,8 @@ trait IRINP extends IRIN {
 case class NthRI(interval: Interval,
                  index: Int,
                  repeatingInterval: RepeatingInterval,
-                 from: Interval.Point = Interval.Start)
-  extends Interval with IRINP {
+                 from: Interval.Point = Interval.Start,
+                 triggerCharSpan: Option[(Int, Int)] = None) extends Interval with IRINP {
   val number = IntNumber(1)
   lazy val fromPoint = intervalsFromPoint.drop(index - 1).next
   lazy override val isDefined = interval.isDefined && repeatingInterval.isDefined && number.isDefined & (interval contains fromPoint)
@@ -584,16 +637,18 @@ case class NthRI(interval: Interval,
 case class NthRIs(interval: Interval, index: Int,
                   repeatingInterval: RepeatingInterval,
                   number: Number = IntNumber(1),
-                  from: Interval.Point = Interval.Start)
-  extends Intervals with IRINP {
+                  from: Interval.Point = Interval.Start,
+                  triggerCharSpan: Option[(Int, Int)] = None) extends Intervals with IRINP {
   lazy val intervals: Seq[Interval] = intervalsFromPoint.grouped(integer).drop(index - 1).next match {
     case result if result.forall(interval.contains) => result
     case result => throw new UnsupportedOperationException(s"one of $result is outside of $interval")
   }
 }
 
-case class IntersectionI(intervals: Seq[Interval]) extends Interval {
+case class IntersectionI(intervals: Seq[Interval],
+                         triggerCharSpan: Option[(Int, Int)] = None) extends Interval {
   val isDefined: Boolean = intervals.forall(_.isDefined)
+  val charSpan: Option[(Int, Int)] = maxSpan(intervals.map(_.charSpan) :+ triggerCharSpan)
   implicit val ldtOrdering: Ordering[LocalDateTime] = Ordering.fromLessThan(_ isBefore _)
   lazy val Interval(start, end) = intervals.sortBy(_.start).reduceLeft[Interval] {
     case (i1, i2) if i1.end.isAfter(i2.start) =>
@@ -627,8 +682,11 @@ private[formal] object RepeatingInterval {
   }
 }
 
-case class RepeatingUnit(unit: TemporalUnit, modifier: Modifier = Modifier.Exact) extends RepeatingInterval {
-  val isDefined = modifier == Modifier.Exact
+case class RepeatingUnit(unit: TemporalUnit,
+                         modifier: Option[Modifier] = None,
+                         triggerCharSpan: Option[(Int, Int)] = None) extends RepeatingInterval {
+  val isDefined: Boolean = modifier.forall(_.isInstanceOf[Modifier.Exact])
+  val charSpan: Option[(Int, Int)] = maxSpan(Seq(modifier.flatMap(_.charSpan), triggerCharSpan))
   override val base: TemporalUnit = unit
   override val range: TemporalUnit = unit
 
@@ -656,8 +714,12 @@ case class RepeatingUnit(unit: TemporalUnit, modifier: Modifier = Modifier.Exact
   }
 }
 
-case class RepeatingField(field: TemporalField, value: Long, modifier: Modifier = Modifier.Exact) extends RepeatingInterval {
-  val isDefined = field.range.isValidValue(value) && modifier == Modifier.Exact
+case class RepeatingField(field: TemporalField,
+                          value: Long,
+                          modifier: Option[Modifier] = None,
+                          triggerCharSpan: Option[(Int, Int)] = None) extends RepeatingInterval {
+  val isDefined: Boolean = field.range.isValidValue(value) && modifier.forall(_.isInstanceOf[Modifier.Exact])
+  val charSpan: Option[(Int, Int)] = maxSpan(Seq(modifier.flatMap(_.charSpan), triggerCharSpan))
   override val base: TemporalUnit = field.getBaseUnit
   override val range: TemporalUnit = field.getRangeUnit
 
@@ -705,8 +767,10 @@ case class RepeatingField(field: TemporalField, value: Long, modifier: Modifier 
   }
 }
 
-case class UnionRI(repeatingIntervals: Set[RepeatingInterval]) extends RepeatingInterval {
+case class UnionRI(repeatingIntervals: Set[RepeatingInterval],
+                   triggerCharSpan: Option[(Int, Int)] = None) extends RepeatingInterval {
   val isDefined: Boolean = repeatingIntervals.forall(_.isDefined)
+  val charSpan: Option[(Int, Int)] = maxSpan(repeatingIntervals.toSeq.map(_.charSpan) :+ triggerCharSpan)
   override val base: TemporalUnit = repeatingIntervals.minBy(_.base.getDuration).base
   override val range: TemporalUnit = repeatingIntervals.maxBy(_.range.getDuration).range
 
@@ -735,8 +799,10 @@ case class UnionRI(repeatingIntervals: Set[RepeatingInterval]) extends Repeating
   }
 }
 
-case class IntersectionRI(repeatingIntervals: Set[RepeatingInterval]) extends RepeatingInterval {
+case class IntersectionRI(repeatingIntervals: Set[RepeatingInterval],
+                          triggerCharSpan: Option[(Int, Int)] = None) extends RepeatingInterval {
   val isDefined: Boolean = repeatingIntervals.forall(_.isDefined)
+  val charSpan: Option[(Int, Int)] = maxSpan(repeatingIntervals.toSeq.map(_.charSpan) :+ triggerCharSpan)
   override val base: TemporalUnit = repeatingIntervals.minBy(_.base.getDuration).base
   override val range: TemporalUnit = repeatingIntervals.maxBy(_.range.getDuration).range
 
@@ -789,7 +855,7 @@ case class IntersectionRI(repeatingIntervals: Set[RepeatingInterval]) extends Re
   }
 }
 
-case class TimeZone(name: String) extends TimeExpression {
+case class TimeZone(name: String, charSpan: Option[(Int, Int)] = None) extends TimeExpression {
   val isDefined = false
 }
 

--- a/src/main/scala/org/clulab/timenorm/neural/TemporalNeuralParser.scala
+++ b/src/main/scala/org/clulab/timenorm/neural/TemporalNeuralParser.scala
@@ -266,16 +266,16 @@ class TemporalNeuralParser(modelFile: Option[InputStream] = None) {
   }
 
   def dct(data: Data): Interval = {
-    val reader = new AnaforaReader(UnknownInterval)(data)
+    val reader = new AnaforaReader(UnknownInterval())(data)
     val time = Try(reader.temporal(data.topEntities(0))(data)).getOrElse(null)
     time match {
       case interval: Interval => interval
       case intervals: Intervals => intervals.head
-      case _ => UnknownInterval
+      case _ => UnknownInterval()
     }
   }
 
-  def intervals(data_batch: List[Data], dct: Option[Interval] = Some(UnknownInterval)): List[List[TimeExpression]] = synchronized {
+  def intervals(data_batch: List[Data], dct: Option[Interval] = Some(UnknownInterval())): List[List[TimeExpression]] = synchronized {
     data_batch.map(data => {
       val reader = new AnaforaReader(dct.get)(data)
       data.topEntities.map(e => {

--- a/src/main/scala/org/clulab/timenorm/neural/TemporalNeuralParser.scala
+++ b/src/main/scala/org/clulab/timenorm/neural/TemporalNeuralParser.scala
@@ -260,7 +260,7 @@ class TemporalNeuralParser(modelStream: Option[InputStream] = None) {
       for (s <- (start until i).reverse) {
 
         // find relations that are valid
-        val relations = for {
+        for {
           (source, target) <- Seq((s, i), (i, s))
           sourceType = timeSpans(source)._3
           targetType = timeSpans(target)._3
@@ -274,10 +274,7 @@ class TemporalNeuralParser(modelStream: Option[InputStream] = None) {
           if ancestors(target).isEmpty
           // don't create cyclic links
           if !ancestors(source).contains(target) && !descendants(target).contains(source)
-        } yield (source, target, propertyName)
-
-        // pick only the first valid relation
-        for ((source, target, propertyName) <- relations.headOption) {
+        } {
           links(source) += propertyName -> target
 
           // update data structures for avoiding cyclic links

--- a/src/main/scala/org/clulab/timenorm/neural/TemporalNeuralParser.scala
+++ b/src/main/scala/org/clulab/timenorm/neural/TemporalNeuralParser.scala
@@ -2,7 +2,6 @@ package org.clulab.timenorm.neural
 
 import java.io._
 import java.nio.file.{FileSystems, Files, Path, PathMatcher, Paths}
-import java.time.{LocalDateTime, ZoneOffset}
 
 import scala.collection.JavaConverters._
 import com.codecommit.antixml._
@@ -14,7 +13,7 @@ import org.tensorflow.Tensor
 import org.apache.commons.io.IOUtils
 import play.api.libs.json._
 
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable
 import scala.io.Source
 import scala.language.postfixOps
 import scala.util.Try
@@ -52,12 +51,11 @@ object TemporalNeuralParser {
     val parser = new TemporalNeuralParser()
     val endsWithXML = FileSystems.getDefault.getPathMatcher("glob:**.xml")
     for ((inPath, outPath) <- parallelPaths(inRoot, outRoot, endsWithXML, timeNormExt)) {
-      val sourceText = List(new String(Files.readAllBytes(inPath)))
-      val annotation = parser.merge(parser.extract(sourceText), sourceText)
-      val xml = parser.build(annotation)
+      val text = new String(Files.readAllBytes(inPath))
+      val xml: Elem = parser.parseToXML(text)
       Files.createDirectories(outPath.getParent)
       val writer = Files.newBufferedWriter(outPath)
-      xml.head.writeTo(writer)
+      xml.writeTo(writer)
       writer.close()
       println(s"$inPath\n$outPath\n")
     }
@@ -77,235 +75,210 @@ object TemporalNeuralParser {
 }
 
 
-case class Span(start: Int, end: Int)
-case class Entity(span: Span, label: String)
-case class Link(parent: Int, child: Int, relation: String)
-case class Property(entity: Int, property: String, value: String)
-case class TimeInterval(start: LocalDateTime, end: LocalDateTime, duration: Long)
-case class TimeExpression(span: Span, intervals: List[TimeInterval])
-case class Annotation(entities: List[List[Entity]], links: List[List[Link]], properties: List[List[Property]])
-
-class TemporalNeuralParser(modelFile: Option[InputStream] = None) {
-  private type Entities = List[List[Entity]]
-  private type Links = List[List[Link]]
-  private type Properties = List[List[Property]]
+class TemporalNeuralParser(modelStream: Option[InputStream] = None) {
 
   lazy private val network = {
     val graph = new Graph()
     graph.importGraphDef(IOUtils.toByteArray(
-      modelFile.getOrElse(this.getClass.getResourceAsStream("/org/clulab/timenorm/model/weights-improvement-22.pb"))))
+      modelStream.getOrElse(this.getClass.getResourceAsStream("/org/clulab/timenorm/model/weights-improvement-22.pb"))))
     new Session(graph)
   }
-  lazy private val char2int = readDict(this.getClass.getResourceAsStream("/org/clulab/timenorm/vocab/dictionary.json"))
-  lazy private val operatorLabels = Source.fromInputStream(this.getClass.getResourceAsStream("/org/clulab/timenorm/label/operator.txt")).getLines.toList
-  lazy private val nonOperatorLabels = Source.fromInputStream(this.getClass.getResourceAsStream("/org/clulab/timenorm/label/non-operator.txt")).getLines.toList
-  lazy private val types = Source.fromInputStream(this.getClass.getResourceAsStream("/org/clulab/timenorm/linking_configure/date-types.txt")).getLines
-                            .map(_.split(' ')).map(a => (a(0), (a(2), a(1)))).toList.groupBy(_._1).mapValues(_.map(_._2).toMap)
-  lazy private val schema = (for {
-      es <- scala.xml.XML.load(this.getClass.getResourceAsStream("/org/clulab/timenorm/linking_configure/timenorm-schema.xml")) \\ "entities"
-      e <- es \ "entity"
-    } yield (
-      (e \\ "property" ).map(p =>
-        ((e \ "@type" head).toString, ((p \ "@type" head).toString, (Try((p \ "@required" head).toString.toBoolean).getOrElse(true), Try((p \ "@instanceOf" head).toString.split(",")).getOrElse(Array()))))
-      )
-      :+
-      ((e \ "@type" head).toString, ("parentType", (true, Array((es \ "@type" head).toString))))
-  )).flatten.groupBy(_._1).mapValues(_.map(_._2).toMap)
 
-
-  private def readDict(dictFile: InputStream): Map[String, Float] = {
-    try {  Json.parse(dictFile).as[Map[String, Float]] } finally { dictFile.close() }
-  }
-
-  private def extract_interval(interval: Interval): TimeInterval = TimeInterval(
-    interval.start,
-    interval.end,
-    interval.end.toEpochSecond(ZoneOffset.UTC) - interval.start.toEpochSecond(ZoneOffset.UTC)
-  )
-
-  private def cleanText(text: List[String]): List[String] = {
-    val antixml_not_allowed = """[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD]+""".r
-    text.map(antixml_not_allowed.replaceAllIn(_, " "))
-  }
-
-  private def identification(sourceText: List[String]): Entities = {
-    val formatText = sourceText.map(s => "\n\n\n" + s + "\n\n\n")
-    val max_seq = formatText.map(_.length).max
-    val padd =   formatText.map(s => Vector.fill(max_seq - s.length)(4.0.toFloat))
-    // Convert the sentences into character code TF Tensor.
-    val input = Tensor.create(formatText.zipWithIndex.map(s => s._1.map(c => this.char2int.getOrElse(c.toString, this.char2int("<unk>"))).toArray ++ padd(s._2)).toArray)
-
-    // Run forward pass
-    val results = this.network.runner()
-      .feed("character",input)
-      .fetch("dense_1/truediv").fetch("dense_2/truediv").fetch("dense_3/truediv")
-      .run()
-
-    // Take the slice of output removing the \n characters and the padding. For each position take the index of the max output. Get the label of that index.
-    val labels = (x: Array[Array[Float]], p: Int, l: List[String]) => x.slice(3, max_seq - (p + 3)).map(r => r.indexWhere(i => i == r.max)).toList.map(o => Try(l(o-1)).getOrElse("O"))
-
-    // Slide through label list and get position where the label type changes. Slide through the resulting list and build the spans as current_position(start), next_position(end), current_label. Remove the "O"s
-    val spans = (x: List[String]) => ("" +: x :+ "").sliding(2).zipWithIndex.filter(f => f._1.head != f._1(1)).sliding(2).map(m =>(m.head._2, m(1)._2, m.head._1(1))).filter(_._3 != "O").toList
-
-    // Complete the annotation if the span does not cover the whole token
-    val re = """[^a-zA-Z\d]""".r
-    val spaces = formatText.map(s => re.findAllMatchIn(s.drop(3).dropRight(3)).map(_.start).toList) // get no-letter characters in sourceText
-    val fullSpans = (x: List[(Int,Int,String)], b: Int) => x.map(s => Entity(
-      Span(s._1 - Try(spaces(b).map((s._1 - 1) - _).filter(_ >= 0).min).getOrElse(0),
-           s._2 + Try(spaces(b).map(_ - s._2).filter(_ >= 0).min).getOrElse(0)),
-      s._3
-    ))
-    
-    formatText.indices.map(b => {
-      val nonOperators = labels(results.get(0).copyTo(Array.ofDim[Float](results.get(0).shape()(0).toInt, results.get(0).shape()(1).toInt, results.get(0).shape()(2).toInt))(b), padd(b).size, nonOperatorLabels)
-      val expOperators = labels(results.get(1).copyTo(Array.ofDim[Float](results.get(1).shape()(0).toInt, results.get(1).shape()(1).toInt, results.get(1).shape()(2).toInt))(b), padd(b).size, operatorLabels)
-      val impOperators = labels(results.get(2).copyTo(Array.ofDim[Float](results.get(2).shape()(0).toInt, results.get(2).shape()(1).toInt, results.get(2).shape()(2).toInt))(b), padd(b).size, operatorLabels)
-      val nonOperatorsSpan = spans(nonOperators)
-      val expOperatorsSpan = spans(expOperators)
-      val impOperatorsSpan = spans(impOperators)
-      
-      (fullSpans(nonOperatorsSpan, b) ::: fullSpans(expOperatorsSpan, b) ::: fullSpans(impOperatorsSpan, b)).sortBy(_.span.start)
-    }).toList
-  }
-
-  private def relation(type1: String, type2: String): Option[String] = {
-    Try(Some(this.schema(type1).toList.filter(_._2._2 contains type2).map(_._1).sorted.reverse.head)).getOrElse(None)
-  }
-
-  private def linking(entitiy_batch: Entities): Links = {
-    entitiy_batch.map(entities => {
-      val links = ListBuffer.empty[Link]
-      val stack = Array(0, 0)
-      for ((entity, i) <- entities.zipWithIndex) {
-        if (stack(0) != stack(1) && entity.span.start - entities(stack(1)-1).span.end > 10)
-          stack(0) = stack(1)
-        for (s <- (stack(0) until stack(1)).toList.reverse) {
-            relation(entities(s).label, entity.label) match {
-              case Some(result) => links += Link(s, i, result)
-              case None => relation(entity.label, entities(s).label) match {
-                case Some(result) => links += Link(i, s, result)
-                case None =>
-              }
-            }
-          }
-          stack(1) += 1
-        }
-        links.groupBy(_.parent).values.map(_.head).toList
-      })
-  }
-
-  private def complete(entitiy_batch: Entities, link_batch: Links, sourceText_batch: List[String]): Properties = {
-    (entitiy_batch zip link_batch zip sourceText_batch).map({ case ((entities, links), sourceText) =>
-      val properties = {
-        for {(entity, i) <- entities.zipWithIndex
-             propertyType <- this.schema(entity.label).keys
-             property: Option[Property] = propertyType match {
-                case "Type" =>
-                  val p = Try(this.types(entity.label)(sourceText.slice(entity.span.start, entity.span.end))).getOrElse(sourceText.slice(entity.span.start, entity.span.end)).toString
-                  (entity.label, p.last.toString) match {
-                    case ("Calendar-Interval", "s") => Some(Property(i, propertyType, p.dropRight(1)))
-                    case ("Period", l) if l != "Unknown" && l != "s" => Some(Property(i, propertyType, p + "s"))
-                    case _ => Some(Property(i, propertyType, p))
-                  }
-                case "Value" =>
-                  val rgx = """^0*(\d+)[^\d]*$""".r
-                  Some(Property(i, propertyType, WordToNumber.convert(rgx.replaceAllIn(sourceText.slice(entity.span.start, entity.span.end), _.group(1)))))
-                case intervalttype if intervalttype contains "Interval-Type" =>
-                   if (links.exists(l => (l.parent == i || l.child == i) && (intervalttype contains l.relation)))
-                     Some(Property(i, propertyType, "Link"))
-                  else
-                     Some(Property(i, propertyType, "DocTime"))
-                case "Semantics" => entity.label match {
-                  case "Last" => Some(Property(i, propertyType, "Interval-Not-Included")) // TODO: Include journal Last
-                  case _ => Some(Property(i, propertyType, "Interval-Not-Included"))
-                }
-                case intervalttype if intervalttype contains "Included" =>
-                  Some(Property(i, propertyType, "Included"))
-                case _ => None
-              }
-             if property.isDefined
-        } yield property.get
-      }
-      properties
-    })
-  }
-
-  private def build(annotations: Annotation): List[Elem] = {
-    (annotations.entities zip annotations.links zip annotations.properties).map({ case ((entities, links), properties) =>
-      <data>
-        <annotations>
-          {for ((entity, e) <- entities.zipWithIndex) yield {
-          <entity>
-            <id>{s"$e@id"}</id>
-            <span>{s"${entity.span.start},${entity.span.end}"}</span>
-            <type>{entity.label}</type>
-            <properties>
-              {links.filter(_.parent == e).map(link => <xml>{s"${link.child}@id"}</xml>.copy(label = link.relation))}
-              {properties.filter(_.entity == e).map(property => <xml>{property.value}</xml>.copy(label = property.property))}
-            </properties>
-          </entity>
-        }}
-        </annotations>
-      </data>.convert
-    })
-  }
-
-
-  def extract(sourceText: List[String]): Annotation = {
-    val entities = identification(sourceText)
-    val links = linking(entities)
-    val properties = complete(entities, links, cleanText(sourceText))
-    Annotation(entities, links, properties)
-  }
-
-  def parse(sourceText: List[String]): List[Data] =  {
-    val annotations = extract(sourceText)
-    val xml: List[Elem] = build(annotations)
-    val data = (xml zip cleanText(sourceText)).map(b => new Data(b._1, Some(b._2)))
-    data
-  }
-
-  def dct(data: Data): Interval = {
-    val reader = new AnaforaReader(UnknownInterval())(data)
-    val time = Try(reader.temporal(data.topEntities(0))(data)).getOrElse(null)
-    time match {
-      case interval: Interval => interval
-      case intervals: Intervals => intervals.head
-      case _ => UnknownInterval()
+  // indices are Ints, but since tensors are filled with Float, it's more efficient to save them as Float
+  lazy private val char2Index: Map[Char, Float] = {
+    val dictStream = this.getClass.getResourceAsStream("/org/clulab/timenorm/vocab/dictionary.json")
+    try {
+      val string2int = Json.parse(dictStream).as[Map[String, Int]]
+      val char2int = for ((string, value) <- string2int; if string.length == 1) yield (string.head, value.toFloat)
+      char2int.withDefaultValue(string2int("<unk>"))
+    } finally {
+      dictStream.close()
     }
   }
 
-  def intervals(data_batch: List[Data], dct: Option[Interval] = Some(UnknownInterval())): List[List[TimeExpression]] = synchronized {
-    data_batch.map(data => {
-      val reader = new AnaforaReader(dct.get)(data)
-      data.topEntities.map(e => {
-        val span = e.expandedSpan(data)
-        val time = Try(reader.temporal(e)(data)).getOrElse(null)
-        val timeIntervals: List[TimeInterval] = Try(time match {
-          case interval: Interval => List(extract_interval(interval))
-          case intervals: Intervals => intervals.map(extract_interval).toList
-          case rInterval: RepeatingInterval => List(TimeInterval(
-            null,
-            null,
-            rInterval.preceding(LocalDateTime.now).next.end.toEpochSecond(ZoneOffset.UTC) - rInterval.preceding(LocalDateTime.now).next.start.toEpochSecond(ZoneOffset.UTC)
-          ))
-          case period: SimplePeriod => List(TimeInterval(
-            null,
-            null,
-            period.number * period.unit.getDuration.getSeconds
-          ))
-          case _ => List(TimeInterval(null, null, 0.toLong))
-        }).getOrElse(List(TimeInterval(null, null, 0.toLong)))
-        TimeExpression(Span(span._1, span._2), timeIntervals)
-      }).toList
-    })
+  lazy private val operatorLabels = Source.fromInputStream(this.getClass.getResourceAsStream("/org/clulab/timenorm/label/operator.txt")).getLines.toIndexedSeq
+  lazy private val nonOperatorLabels = Source.fromInputStream(this.getClass.getResourceAsStream("/org/clulab/timenorm/label/non-operator.txt")).getLines.toIndexedSeq
+  lazy private val types = Source.fromInputStream(this.getClass.getResourceAsStream("/org/clulab/timenorm/linking_configure/date-types.txt")).getLines
+                            .map(_.split(' ')).map(a => (a(0), (a(2), a(1)))).toIndexedSeq.groupBy(_._1).mapValues(_.map(_._2).toMap)
+
+  // TODO: this is ugly
+  lazy private val schema = (for {
+    es <- scala.xml.XML.load(this.getClass.getResourceAsStream("/org/clulab/timenorm/linking_configure/timenorm-schema.xml")) \\ "entities"
+    e <- es \ "entity"
+  } yield (
+    (e \\ "property").map(p =>
+      ((e \ "@type" head).toString, ((p \ "@type" head).toString, (Try((p \ "@required" head).toString.toBoolean).getOrElse(true), Try((p \ "@instanceOf" head).toString.split(",")).getOrElse(Array()))))
+    )
+      :+
+      ((e \ "@type" head).toString, ("parentType", (true, Array((es \ "@type" head).toString))))
+    )).flatten.groupBy(_._1).mapValues(_.map(_._2).toMap)
+
+  def parse(text: String, textCreationTime: Interval = UnknownInterval()): Array[TimeExpression] = {
+    parseBatch(text, Array((0, text.length)), textCreationTime) match {
+      case Array(timeExpressions) => timeExpressions
+    }
   }
 
-  def merge(annotation: Annotation, sourceText: List[String]): Annotation = {
-    val startOffsets = sourceText.dropRight(1).foldLeft(List(0))({ case (l, s) => s.length + l.head + 1 :: l }).reverse
-    val prevNumEntities = annotation.entities.dropRight(1).foldLeft(List(0))({ case (l, e) => e.size + l.head :: l }).reverse
-    Annotation(List((annotation.entities zip startOffsets).flatMap { case (b, o) => b.map(e => Entity(Span(e.span.start + o, e.span.end + o), e.label)) }),
-              List((annotation.links zip prevNumEntities).flatMap { case (b, n) => b.map{l => Link(l.parent + n, l.child + n, l.relation)}}),
-              List((annotation.properties zip prevNumEntities).flatMap { case (b, n) => b.map{p => Property(p.entity + n, p.property, p.value)}}))
+  def parseToXML(text: String): Elem = {
+    parseBatchToXML(text, Array((0, text.length))) match {
+      case Array(xml) => xml
+    }
+  }
+
+  def parseBatch(text: String,
+                 spans: Array[(Int, Int)],
+                 textCreationTime: Interval = UnknownInterval()): Array[Array[TimeExpression]] = {
+    for (xml <- parseBatchToXML(text, spans)) yield {
+      implicit val data: Data = new Data(xml, Some(text))
+      val reader = new AnaforaReader(textCreationTime)
+      data.topEntities.map(reader.temporal).toArray
+    }
+  }
+
+  def parseBatchToXML(text: String, spans: Array[(Int, Int)]): Array[Elem] = {
+    val antixmlCleanedText = """[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD]+""".r.replaceAllIn(text, " ")
+
+    val allTimeSpans = identifyBatch(text, spans)
+    val timeSpanToId = allTimeSpans.flatten.zipWithIndex.toMap.mapValues(i => s"$i@id")
+    for (timeSpans <- allTimeSpans) yield {
+      val entityElems = for ((timeSpan, links) <- timeSpans zip inferLinks(timeSpans)) yield {
+        val id = timeSpanToId(timeSpan)
+        val (start, end, timeType) = timeSpan
+        val timeText = antixmlCleanedText.substring(start, end)
+        val linkProperties = for ((relationType, childIndex) <- links) yield
+          <xml>{timeSpanToId(timeSpans(childIndex))}</xml>.copy(label = relationType)
+        val textProperties = for ((propertyType, propertyValue) <- inferProperties(timeText, timeType, links)) yield
+          <xml>{propertyValue}</xml>.copy(label = propertyType)
+        <entity>
+          <id>{id}</id>
+          <span>{s"$start,$end"}</span>
+          <type>{timeType}</type>
+          <properties>
+            {linkProperties ++ textProperties}
+          </properties>
+        </entity>
+      }
+      <data>
+        <annotations>
+          {entityElems}
+        </annotations>
+      </data>.convert
+    }
+  }
+
+
+  private def identifyBatch(text: String, spans: Array[(Int, Int)]): Array[Array[(Int, Int, String)]] = {
+    val expandedTexts = spans.map {
+      case (start, end) => "\n\n\n" + text.substring(start, end) + "\n\n\n"
+    }
+    val maxLen = expandedTexts.map(_.length).max
+    val inputArray = expandedTexts.map(_.map(char2Index).padTo(maxLen, 4f).toArray)
+    val input = Tensor.create(inputArray)
+
+    val re = """[^a-zA-Z\d]""".r
+    val textInfos = spans.map {
+      case (start, end) =>
+        val snippet = text.substring(start, end)
+        (start, snippet, re.findAllMatchIn(snippet).map(start + _.start).toSeq)
+    }
+
+    // Run forward pass
+    val tensors = this.network.runner()
+
+      .feed("character",input)
+      .fetch("dense_1/truediv").fetch("dense_2/truediv").fetch("dense_3/truediv")
+      .run().asScala
+
+    val Seq(nonOperators, expOperators, impOperators) = for {
+      (labels, tensor) <- Seq(nonOperatorLabels, operatorLabels, operatorLabels) zip tensors
+    } yield {
+      val Array(nBatches, nChars, nCategories) = tensor.shape.map(_.toInt)
+      val allPredictions = tensor.copyTo(Array.ofDim[Float](nBatches, nChars, nCategories))
+      for (((textStart, snippet, spaceIndices), predictions) <- textInfos zip allPredictions) yield {
+
+        // select the most probable label for each character
+        val predictedLabels = for (categoryScores <- predictions.slice(3, 3 + snippet.length)) yield {
+          val maxScore = categoryScores.max
+          val maxIndex = categoryScores.indexWhere(_ == maxScore)
+          labels.lift(maxIndex - 1).getOrElse("O")
+        }
+
+        // Slide through label list and get position where the label type changes.
+        val changesWithIndex = for {
+          (Array(label1, label2), index) <- ("" +: predictedLabels :+ "").sliding(2).zipWithIndex
+          if label1 != label2
+        } yield (label2, textStart + index)
+
+        // build the spans as current_position(start), next_position(end), current_label. Remove the "O"s
+        val labeledSpans = for {
+          Seq((label, start), (_, end)) <- changesWithIndex.sliding(2)
+          if label != "O"
+        } yield {
+
+          // Complete the annotation if the span does not cover the whole token
+          val startAdjustment = Try(spaceIndices.map((start - 1) - _).filter(_ >= 0).min).getOrElse(0)
+          val endAdjustment = Try(spaceIndices.map(_ - end).filter(_ >= 0).min).getOrElse(0)
+          (start - startAdjustment, end + endAdjustment, label)
+        }
+
+        labeledSpans.toArray
+      }
+    }
+
+    // for each batch, combine the different time operators into a single array
+    for (i <- expandedTexts.indices.toArray) yield {
+      val operators = nonOperators(i) ++ expOperators(i) ++ impOperators(i)
+      operators.sortBy { case (start, _, _) => start }
+    }
+  }
+
+  private def inferLinks(timeSpans: Array[(Int, Int, String)]): Array[Array[(String, Int)]] = {
+    val links = Array.fill(timeSpans.length)(mutable.ArrayBuffer.empty[(String, Int)])
+    val stack = Array(0, 0)
+    for ((timeSpan, i) <- timeSpans.zipWithIndex) {
+      if (stack(0) != stack(1) && timeSpan._1 - timeSpans(stack(1)-1)._2 > 10)
+        stack(0) = stack(1)
+      for {
+        s <- (stack(0) until stack(1)).toList.reverse
+        label <- relation(timeSpans(s)._3, timeSpan._3).orElse(relation(timeSpan._3, timeSpans(s)._3))
+      } {
+        links(s) += label -> i
+      }
+      stack(1) += 1
+    }
+    links.map(_.toArray)
+  }
+
+  private def inferProperties(timeText: String, timeType: String, links: Array[(String, Int)]): Array[(String, String)] = {
+    val propertyOptions = for (propertyType <- this.schema(timeType).keys) yield propertyType match {
+       case "Type" =>
+         val p = Try(this.types(timeType)(timeText)).getOrElse(timeText).toString
+         (timeType, p.last) match {
+           case ("Calendar-Interval", 's') => Some((propertyType, p.dropRight(1)))
+           case ("Period", l) if p != "Unknown" && l != 's' => Some((propertyType, p + "s"))
+           case _ => Some((propertyType, p))
+         }
+       case "Value" =>
+         val rgx = """^0*(\d+)[^\d]*$""".r
+         Some((propertyType, WordToNumber.convert(rgx.replaceAllIn(timeText, _.group(1)))))
+       case intervalType if intervalType contains "Interval-Type" =>
+         if (links.exists{ case (relationType, _) => intervalType contains relationType})
+           Some((propertyType, "Link"))
+         else
+           Some((propertyType, "DocTime"))
+       case "Semantics" => timeType match {
+         case "Last" => Some((propertyType, "Interval-Not-Included")) // TODO: Include journal Last
+         case _ => Some((propertyType, "Interval-Not-Included"))
+       }
+       case intervalType if intervalType contains "Included" =>
+         Some((propertyType, "Included"))
+       case _ => None
+     }
+    propertyOptions.flatten.toArray
+  }
+
+  private def relation(type1: String, type2: String): Option[String] = {
+    // TODO: this is ugly
+    Try(Some(this.schema(type1).toList.filter(_._2._2 contains type2).map(_._1).sorted.reverse.head)).getOrElse(None)
   }
 }

--- a/src/test/scala/org/clulab/timenorm/formal/ReadersTest.scala
+++ b/src/test/scala/org/clulab/timenorm/formal/ReadersTest.scala
@@ -74,7 +74,9 @@ class ReadersTest extends FunSuite with TypesSuite {
     temporals match {
       case Seq(year: Interval, _: RepeatingInterval, _: RepeatingInterval, noon: RepeatingField) =>
         assert(year === SimpleInterval.of(2000, 10, 25, 12, 0))
+        assert(year.charSpan === Some((0, 15)))
         assert(noon.field === ChronoField.MINUTE_OF_DAY)
+        assert(noon.charSpan === Some((11, 15)))
       case _ => fail("expected Seq(year: I, month: RI, day: RI, noon: RI), found " + temporals)
     }
   }
@@ -139,6 +141,11 @@ class ReadersTest extends FunSuite with TypesSuite {
     temporals match {
       case Seq(nth: NthRIs, number: Number, month: RepeatingInterval, year: Year) =>
         assert(nth === SimpleIntervals((1 to 9).map(m => SimpleInterval.of(1997, m))))
+        assert(nth.charSpan === Some((0, 25)))
+        assert(number.charSpan === Some((6, 10)))
+        // we currently don't attach Numbers to RepeatingIntervals
+        // assert(month.charSpan === Some((6, 17)))
+        assert(year.charSpan === Some((21, 25)))
       case _ => fail("expected Seq(nth: NRIs, number: N, month: RI, year: Y), found " + temporals)
     }
   }
@@ -188,7 +195,9 @@ class ReadersTest extends FunSuite with TypesSuite {
     val aReader = new AnaforaReader(dct)
     val temporals = data.entities.map(aReader.temporal)
     temporals match {
-      case Seq(last: Last, _: Number, _: RepeatingInterval) => assert(!last.isDefined)
+      case Seq(last: Last, _: Number, _: RepeatingInterval) =>
+        assert(!last.isDefined)
+        assert(last.charSpan === Some((0, 15)))
       case _ => fail("expected Seq(last: Last, number: N, month: RI), found " + temporals)
     }
   }
@@ -242,6 +251,7 @@ class ReadersTest extends FunSuite with TypesSuite {
     temporals match {
       case Seq(year: Interval, _: RepeatingInterval, _: RepeatingInterval) =>
         assert(year === SimpleInterval.of(1998, 3, 31))
+        assert(year.charSpan === Some((0, 8)))
       case _ => fail("expected Seq(year: Y, month: RI, day: RI), found " + temporals)
     }
   }
@@ -283,7 +293,10 @@ class ReadersTest extends FunSuite with TypesSuite {
     val aReader = new AnaforaReader(dct)
     val temporals = data.entities.map(aReader.temporal)
     temporals match {
-      case Seq(friday: RepeatingInterval, last: LastRI) => assert(last === SimpleInterval(start, start.plusDays(1)))
+      case Seq(friday: RepeatingInterval, last: LastRI) =>
+        assert(last === SimpleInterval(start, start.plusDays(1)))
+        assert(friday.charSpan === Some((0, 6)))
+        assert(last.charSpan === Some((0, 6)))
       case _ => fail("expected Seq(friday: RI, last: Last), found " + temporals)
     }
   }
@@ -358,6 +371,8 @@ class ReadersTest extends FunSuite with TypesSuite {
       case Seq(_: RepeatingInterval, last: LastRI, _: BeforeP, _: Event, intersection: IntersectionI) =>
         assert(last === SimpleInterval.of(1998, 3, 22))
         assert(!intersection.isDefined)
+        assert(last.charSpan === Some((3926,3932)))
+        assert(intersection.charSpan === Some((3750, 3932)))
       case _ => fail("expected Seq(sunday: RI, last: I, before: I, event: I, intersection: I), found " + temporals)
     }
   }
@@ -419,6 +434,7 @@ class ReadersTest extends FunSuite with TypesSuite {
     temporals match {
       case Seq(_: RepeatingInterval, _: RepeatingInterval, _: ThisRI, intersection: Intervals) =>
         assert(intersection === SimpleIntervals(Seq(SimpleInterval.of(1998, 1))))
+        assert(intersection.charSpan === Some((1164, 1181)))
       case _ => fail("expected Seq(january: RI, year: RI, this: I, intersection: Is), found " + temporals)
     }
   }
@@ -448,6 +464,7 @@ class ReadersTest extends FunSuite with TypesSuite {
       case Seq(quarterCentury: RepeatingInterval) =>
         assert(ThisRI(dct, quarterCentury)
           === SimpleInterval(LocalDateTime.of(1975, 1, 1, 0, 0), LocalDateTime.of(2000, 1, 1, 0, 0)))
+        assert(quarterCentury.charSpan === Some((1095, 1110)))
       case _ => fail("expected Seq(quarter-century: RI), found " + temporals)
     }
   }
@@ -489,6 +506,7 @@ class ReadersTest extends FunSuite with TypesSuite {
     temporals match {
       case Seq(_: RepeatingInterval, nth: NthRI) =>
         assert(nth === SimpleInterval(LocalDateTime.of(1900, 1, 1, 0, 0), LocalDateTime.of(2000, 1, 1, 0, 0)))
+        assert(nth.charSpan === Some((484, 496)))
       case _ => fail("expected Seq(century: RI, 20th: I), found " + temporals)
     }
   }
@@ -530,6 +548,7 @@ class ReadersTest extends FunSuite with TypesSuite {
     temporals match {
       case Seq(_: RepeatingInterval, nth: NthRI) =>
         assert(nth === SimpleInterval(LocalDateTime.of(1989, 7, 1, 0, 0), LocalDateTime.of(1989, 10, 1, 0, 0)))
+        assert(nth.charSpan === Some((287, 300)))
       case _ => fail("expected Seq(quarter: RI, 3rd: I), found " + temporals)
     }
   }
@@ -558,8 +577,8 @@ class ReadersTest extends FunSuite with TypesSuite {
     val temporals = data.entities.map(aReader.temporal)
     temporals match {
       case Seq(year: YearSuffix) =>
-        assert(year
-          === SimpleInterval.of(2000))
+        assert(year === SimpleInterval.of(2000))
+        assert(year.charSpan === Some((6422,6424)))
       case _ => fail("expected Seq(year: YearSuffix), found " + temporals)
     }
   }

--- a/src/test/scala/org/clulab/timenorm/formal/TypesTest.scala
+++ b/src/test/scala/org/clulab/timenorm/formal/TypesTest.scala
@@ -101,9 +101,8 @@ class TypesTest extends FunSuite with TypesSuite {
     val ldt = LocalDateTime.of(2000, 1, 1, 0, 0, 0, 0)
     val number = IntNumber(5)
     val unit = ChronoUnit.YEARS
-    val mod = Modifier.Exact
 
-    val simple = SimplePeriod(unit, number, mod)
+    val simple = SimplePeriod(unit, number)
     assert(simple.addTo(ldt) === LocalDateTime.of(2005, 1, 1, 0, 0, 0, 0))
     assert(simple.subtractFrom(ldt) === LocalDateTime.of(1995, 1, 1, 0, 0, 0, 0))
     assert(simple.get(unit) === 5)
@@ -117,16 +116,16 @@ class TypesTest extends FunSuite with TypesSuite {
     val vagueNumber = VagueNumber("A few")
 
     intercept[scala.MatchError] {
-      SimplePeriod(unit, vagueNumber, mod).addTo(ldt)
+      SimplePeriod(unit, vagueNumber).addTo(ldt)
     }
   }
 
   test("SumP") {
-    val period1 = SimplePeriod(ChronoUnit.YEARS, 1, Modifier.Exact)
-    val period2 = SimplePeriod(ChronoUnit.YEARS, 2, Modifier.Fiscal)
-    val period3 = SimplePeriod(ChronoUnit.MONTHS, 3, Modifier.Approx)
-    val period4 = SimplePeriod(ChronoUnit.DAYS, 2, Modifier.Mid)
-    val periodSum = SumP(Set(period1, period2, period3), Modifier.Exact)
+    val period1 = SimplePeriod(ChronoUnit.YEARS, 1, Some(Modifier.Exact()))
+    val period2 = SimplePeriod(ChronoUnit.YEARS, 2, Some(Modifier.Fiscal()))
+    val period3 = SimplePeriod(ChronoUnit.MONTHS, 3, Some(Modifier.Approx()))
+    val period4 = SimplePeriod(ChronoUnit.DAYS, 2, Some(Modifier.Mid()))
+    val periodSum = SumP(Set(period1, period2, period3), Some(Modifier.Exact()))
     val ldt = LocalDateTime.of(2000, 6, 10, 0, 0, 0, 0)
 
     val list = new java.util.ArrayList[TemporalUnit]
@@ -139,7 +138,7 @@ class TypesTest extends FunSuite with TypesSuite {
     assert(periodSum.getUnits() === list)
 
     //Tests for periodSums that contain periodSums
-    val periodSum2 = SumP(Set(period4, periodSum), Modifier.Fiscal)
+    val periodSum2 = SumP(Set(period4, periodSum), Some(Modifier.Fiscal()))
     list.add(ChronoUnit.DAYS)
 
     assert(periodSum2.addTo(ldt) === LocalDateTime.of(2003, 9, 12, 0, 0, 0, 0))
@@ -153,10 +152,10 @@ class TypesTest extends FunSuite with TypesSuite {
   }
 
   test("LastP") {
-    val period1 = SimplePeriod(ChronoUnit.YEARS, 1, Modifier.Exact)
-    val period2 = SimplePeriod(ChronoUnit.YEARS, 2, Modifier.Fiscal)
-    val period3 = SimplePeriod(ChronoUnit.MONTHS, 3, Modifier.Approx)
-    val periodSum = SumP(Set(period1, period2, period3), Modifier.Exact)
+    val period1 = SimplePeriod(ChronoUnit.YEARS, 1, Some(Modifier.Exact()))
+    val period2 = SimplePeriod(ChronoUnit.YEARS, 2, Some(Modifier.Fiscal()))
+    val period3 = SimplePeriod(ChronoUnit.MONTHS, 3, Some(Modifier.Approx()))
+    val periodSum = SumP(Set(period1, period2, period3), Some(Modifier.Exact()))
 
     val year = Year(2000)
     val lastPeriod = LastP(year, period1)
@@ -177,17 +176,17 @@ class TypesTest extends FunSuite with TypesSuite {
       === SimpleInterval(LocalDateTime.of(2017, 8, 17, 0, 0), LocalDateTime.of(2017, 8, 31, 0, 0)))
 
     assert(NextP(Year(2000), SumP(Set(
-      SimplePeriod(ChronoUnit.YEARS, 1, Modifier.Exact),
-      SimplePeriod(ChronoUnit.YEARS, 2, Modifier.Fiscal),
-      SimplePeriod(ChronoUnit.MONTHS, 3, Modifier.Approx))))
+      SimplePeriod(ChronoUnit.YEARS, 1, Some(Modifier.Exact())),
+      SimplePeriod(ChronoUnit.YEARS, 2, Some(Modifier.Fiscal())),
+      SimplePeriod(ChronoUnit.MONTHS, 3, Some(Modifier.Approx())))))
       === SimpleInterval(LocalDateTime.of(2001, 1, 1, 0, 0), LocalDateTime.of(2004, 4, 1, 0, 0, 0, 0)))
   }
 
   test("BeforeP") {
-    val period1 = SimplePeriod(ChronoUnit.YEARS, 1, Modifier.Exact)
-    val period2 = SimplePeriod(ChronoUnit.YEARS, 2, Modifier.Fiscal)
-    val period3 = SimplePeriod(ChronoUnit.MONTHS, 3, Modifier.Approx)
-    val periodSum = SumP(Set(period1, period2, period3), Modifier.Exact)
+    val period1 = SimplePeriod(ChronoUnit.YEARS, 1, Some(Modifier.Exact()))
+    val period2 = SimplePeriod(ChronoUnit.YEARS, 2, Some(Modifier.Fiscal()))
+    val period3 = SimplePeriod(ChronoUnit.MONTHS, 3, Some(Modifier.Approx()))
+    val periodSum = SumP(Set(period1, period2, period3), Some(Modifier.Exact()))
 
     val year = Year(2000)
     val beforePeriod = BeforeP(year, period1)
@@ -207,10 +206,10 @@ class TypesTest extends FunSuite with TypesSuite {
   }
 
   test("AfterP") {
-    val period1 = SimplePeriod(ChronoUnit.YEARS, 1, Modifier.Exact)
-    val period2 = SimplePeriod(ChronoUnit.YEARS, 2, Modifier.Fiscal)
-    val period3 = SimplePeriod(ChronoUnit.MONTHS, 3, Modifier.Approx)
-    val periodSum = SumP(Set(period1, period2, period3), Modifier.Exact)
+    val period1 = SimplePeriod(ChronoUnit.YEARS, 1, Some(Modifier.Exact()))
+    val period2 = SimplePeriod(ChronoUnit.YEARS, 2, Some(Modifier.Fiscal()))
+    val period3 = SimplePeriod(ChronoUnit.MONTHS, 3, Some(Modifier.Approx()))
+    val periodSum = SumP(Set(period1, period2, period3), Some(Modifier.Exact()))
 
     val year = Year(2000)
     val afterPeriod = AfterP(year, period1)
@@ -230,7 +229,7 @@ class TypesTest extends FunSuite with TypesSuite {
   }
 
   test("ThisP") {
-    val period1 = SimplePeriod(ChronoUnit.YEARS, 1, Modifier.Exact)
+    val period1 = SimplePeriod(ChronoUnit.YEARS, 1, Some(Modifier.Exact()))
 
     val year = Year(2002)
     val thisPeriod = ThisP(year, period1)
@@ -239,7 +238,7 @@ class TypesTest extends FunSuite with TypesSuite {
     assert(thisPeriod.end === LocalDateTime.of(2003, 1, 1, 0, 0, 0, 0))
 
     val interval = SimpleInterval(LocalDateTime.of(2001, 1, 1, 0, 0, 0, 0), LocalDateTime.of(2001, 1, 1, 0, 0, 0, 0))
-    val period = SimplePeriod(ChronoUnit.DAYS, 5, Modifier.Exact)
+    val period = SimplePeriod(ChronoUnit.DAYS, 5, Some(Modifier.Exact()))
     val thisPeriod2 = ThisP(interval, period)
 
     assert(thisPeriod2.start === LocalDateTime.of(2000, 12, 29, 12, 0, 0, 0))
@@ -269,16 +268,16 @@ class TypesTest extends FunSuite with TypesSuite {
     val ldt2 = LocalDateTime.of(2003, 5, 11, 22, 10, 20, 0)
     val interval = SimpleInterval(ldt1, ldt2)
 
-    val pre = RepeatingUnit(ChronoUnit.MONTHS, Modifier.Exact).preceding(interval.start)
+    val pre = RepeatingUnit(ChronoUnit.MONTHS, Some(Modifier.Exact())).preceding(interval.start)
     assert(pre.next === SimpleInterval.of(2002, 2))
     assert(pre.next === SimpleInterval.of(2002, 1))
 
-    val follow = RepeatingUnit(ChronoUnit.MONTHS, Modifier.Exact).following(interval.end)
+    val follow = RepeatingUnit(ChronoUnit.MONTHS, Some(Modifier.Exact())).following(interval.end)
     assert(follow.next === SimpleInterval.of(2003, 6))
     assert(follow.next === SimpleInterval.of(2003, 7))
 
     //Truncate method tests
-    val mod = Modifier.End
+    val mod = Some(Modifier.End())
     val centuryRI = RepeatingUnit(ChronoUnit.CENTURIES, mod)
     val decadeRI = RepeatingUnit(ChronoUnit.DECADES, mod)
     val weeksRI = RepeatingUnit(ChronoUnit.WEEKS, mod)
@@ -311,7 +310,7 @@ class TypesTest extends FunSuite with TypesSuite {
 
     val interval2 = SimpleInterval(
       LocalDateTime.of(2001, 2, 12, 3, 3), LocalDateTime.of(2001, 2, 14, 22, 0))
-    val daysRI = RepeatingUnit(ChronoUnit.DAYS, Modifier.Exact)
+    val daysRI = RepeatingUnit(ChronoUnit.DAYS, Some(Modifier.Exact()))
     assert(daysRI.preceding(interval2.start).next === SimpleInterval.of(2001, 2, 11))
     assert(daysRI.following(interval2.end).next === SimpleInterval.of(2001, 2, 15))
 
@@ -331,7 +330,7 @@ class TypesTest extends FunSuite with TypesSuite {
     val interval = SimpleInterval(
       LocalDateTime.of(2002, 3, 22, 11, 30, 30, 0), LocalDateTime.of(2003, 5, 10, 22, 10, 20, 0))
 
-    val monthMay = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Modifier.Exact)
+    val monthMay = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Some(Modifier.Exact()))
     val pre = monthMay.preceding(interval.start)
     assert(pre.next === SimpleInterval.of(2001, 5))
     assert(pre.next === SimpleInterval.of(2000, 5))
@@ -339,7 +338,7 @@ class TypesTest extends FunSuite with TypesSuite {
     assert(post.next === SimpleInterval.of(2004, 5))
     assert(post.next === SimpleInterval.of(2005, 5))
 
-    val day29 = RepeatingField(ChronoField.DAY_OF_MONTH, 29, Modifier.Exact)
+    val day29 = RepeatingField(ChronoField.DAY_OF_MONTH, 29, Some(Modifier.Exact()))
     val pre2 = day29.preceding(interval.start)
     assert(pre2.next === SimpleInterval.of(2002, 1, 29))
     assert(pre2.next === SimpleInterval.of(2001, 12, 29))
@@ -353,7 +352,7 @@ class TypesTest extends FunSuite with TypesSuite {
     assert(nov.following(LocalDateTime.of(1989, 11, 2, 0, 0)).next === SimpleInterval.of(1990, 11))
 
     //No Exception at FieldRepeatingInterval instantiation
-    val day300 = RepeatingField(ChronoField.DAY_OF_MONTH, 300, Modifier.Approx)
+    val day300 = RepeatingField(ChronoField.DAY_OF_MONTH, 300, Some(Modifier.Approx()))
     intercept[DateTimeException] {
       //Exception thrown here
       val testException = day300.preceding(interval.start)
@@ -371,9 +370,9 @@ class TypesTest extends FunSuite with TypesSuite {
   test("LastRI") {
     val interval = SimpleInterval(
       LocalDateTime.of(2002, 3, 22, 11, 30, 30, 0), LocalDateTime.of(2003, 5, 10, 22, 10, 20, 0))
-    val may = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Modifier.Exact)
+    val may = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Some(Modifier.Exact()))
     val friday = RepeatingField(ChronoField.DAY_OF_WEEK, 5)
-    val day = RepeatingUnit(ChronoUnit.DAYS, Modifier.Exact)
+    val day = RepeatingUnit(ChronoUnit.DAYS, Some(Modifier.Exact()))
 
     assert(LastRI(interval, may) === SimpleInterval.of(2001, 5))
     assert(LastRI(interval, day) === SimpleInterval.of(2002, 3, 21))
@@ -401,8 +400,8 @@ class TypesTest extends FunSuite with TypesSuite {
   test("LastRIs") {
     val interval = SimpleInterval(
       LocalDateTime.of(2002, 3, 22, 11, 30, 30, 0), LocalDateTime.of(2003, 5, 10, 22, 10, 20, 0))
-    val may = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Modifier.Exact)
-    val day = RepeatingUnit(ChronoUnit.DAYS, Modifier.Exact)
+    val may = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Some(Modifier.Exact()))
+    val day = RepeatingUnit(ChronoUnit.DAYS, Some(Modifier.Exact()))
 
     //Interval: March 22, 2002 @ 11:30:30 to May 10, 2003 @ 22:10:20
     //FieldRI: May
@@ -420,7 +419,7 @@ class TypesTest extends FunSuite with TypesSuite {
   test("NextRI") {
     val interval = SimpleInterval(
       LocalDateTime.of(2002, 3, 22, 11, 30, 30, 0), LocalDateTime.of(2003, 5, 10, 22, 10, 20, 0))
-    val may = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Modifier.Exact)
+    val may = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Some(Modifier.Exact()))
 
     assert(NextRI(interval, may) === SimpleInterval.of(2004, 5))
     assert(NextRI(interval, RepeatingUnit(ChronoUnit.DAYS)) === SimpleInterval.of(2003, 5, 11))
@@ -435,8 +434,8 @@ class TypesTest extends FunSuite with TypesSuite {
   test("NextRIs") {
     val interval = SimpleInterval(
       LocalDateTime.of(2002, 3, 22, 11, 30, 30, 0), LocalDateTime.of(2003, 5, 10, 22, 10, 20, 0))
-    val may = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Modifier.Exact)
-    val day = RepeatingUnit(ChronoUnit.DAYS, Modifier.Exact)
+    val may = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Some(Modifier.Exact()))
+    val day = RepeatingUnit(ChronoUnit.DAYS, Some(Modifier.Exact()))
 
     //Interval: March 22, 2002 @ 11:30:30 to May 10, 2003 @ 22:10:20
     //FieldRI: May
@@ -456,8 +455,8 @@ class TypesTest extends FunSuite with TypesSuite {
   test("AfterRI") {
     val interval = SimpleInterval(
       LocalDateTime.of(2002, 3, 22, 11, 30, 30, 0), LocalDateTime.of(2003, 5, 10, 22, 10, 20, 0))
-    val may = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Modifier.Exact)
-    val day = RepeatingUnit(ChronoUnit.DAYS, Modifier.Exact)
+    val may = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Some(Modifier.Exact()))
+    val day = RepeatingUnit(ChronoUnit.DAYS, Some(Modifier.Exact()))
 
     assert(AfterRI(interval, may) === SimpleInterval.of(2004, 5))
     assert(AfterRI(interval, may, 10) === SimpleInterval.of(2013, 5))
@@ -471,8 +470,8 @@ class TypesTest extends FunSuite with TypesSuite {
   test("BeforeRI") {
     val interval = SimpleInterval(
       LocalDateTime.of(2002, 3, 22, 11, 30, 30, 0), LocalDateTime.of(2003, 5, 10, 22, 10, 20, 0))
-    val may = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Modifier.Exact)
-    val day = RepeatingUnit(ChronoUnit.DAYS, Modifier.Exact)
+    val may = RepeatingField(ChronoField.MONTH_OF_YEAR, 5, Some(Modifier.Exact()))
+    val day = RepeatingUnit(ChronoUnit.DAYS, Some(Modifier.Exact()))
 
     assert(BeforeRI(interval, may) === SimpleInterval.of(2001, 5))
     assert(BeforeRI(interval, may, 5) === SimpleInterval.of(1997, 5))
@@ -685,8 +684,8 @@ class TypesTest extends FunSuite with TypesSuite {
 
   test("UnionRI") {
     var interval = SimpleInterval(LocalDateTime.of(2003, 1, 1, 0, 0), LocalDateTime.of(2003, 1, 30, 0, 0))
-    val fieldRI = RepeatingField(ChronoField.MONTH_OF_YEAR, 2, Modifier.Exact)
-    val fieldRI2 = RepeatingField(ChronoField.DAY_OF_MONTH, 20, Modifier.Exact)
+    val fieldRI = RepeatingField(ChronoField.MONTH_OF_YEAR, 2, Some(Modifier.Exact()))
+    val fieldRI2 = RepeatingField(ChronoField.DAY_OF_MONTH, 20, Some(Modifier.Exact()))
     var unionRI = UnionRI(Set(fieldRI, fieldRI2))
 
     assert(unionRI.base === ChronoUnit.DAYS)
@@ -767,7 +766,7 @@ class TypesTest extends FunSuite with TypesSuite {
     //Interval: July 1 to July 30, 2011
     //UnitRI: Weeks
     //FieldRI: 20th of the month
-    val fieldRI3 = RepeatingField(ChronoField.DAY_OF_MONTH, 20, Modifier.Exact)
+    val fieldRI3 = RepeatingField(ChronoField.DAY_OF_MONTH, 20, Some(Modifier.Exact()))
     unionRI = UnionRI(Set(unitRI1, fieldRI3))
 
     //Preceding
@@ -847,9 +846,9 @@ class TypesTest extends FunSuite with TypesSuite {
     //January, Friday the 13th
     var intersectRI = IntersectionRI(
       Set(
-        RepeatingField(ChronoField.DAY_OF_WEEK, 5, Modifier.Exact), //Friday
-        RepeatingField(ChronoField.DAY_OF_MONTH, 13, Modifier.Exact), //the 13th
-        RepeatingField(ChronoField.MONTH_OF_YEAR, 1, Modifier.Exact)) //January
+        RepeatingField(ChronoField.DAY_OF_WEEK, 5, Some(Modifier.Exact())), //Friday
+        RepeatingField(ChronoField.DAY_OF_MONTH, 13, Some(Modifier.Exact())), //the 13th
+        RepeatingField(ChronoField.MONTH_OF_YEAR, 1, Some(Modifier.Exact()))) //January
     )
 
     assert(intersectRI.base === ChronoUnit.DAYS)
@@ -886,8 +885,8 @@ class TypesTest extends FunSuite with TypesSuite {
     //RI: The hours of Friday the 13th
     intersectRI = IntersectionRI(
       Set(
-        RepeatingField(ChronoField.DAY_OF_WEEK, 5, Modifier.Exact), //Friday
-        RepeatingField(ChronoField.DAY_OF_MONTH, 13, Modifier.Exact), //the 13th
+        RepeatingField(ChronoField.DAY_OF_WEEK, 5, Some(Modifier.Exact())), //Friday
+        RepeatingField(ChronoField.DAY_OF_MONTH, 13, Some(Modifier.Exact())), //the 13th
         RepeatingUnit(ChronoUnit.HOURS) //Hours
       ))
     //Interval: The year of 2016
@@ -946,9 +945,9 @@ class TypesTest extends FunSuite with TypesSuite {
     val threeDays = SimplePeriod(ChronoUnit.DAYS, 3)
     val fridays = RepeatingField(ChronoField.DAY_OF_WEEK, 5)
     assert(threeDays.isDefined === true)
-    assert(UnknownPeriod.isDefined === false)
+    assert(UnknownPeriod().isDefined === false)
     assert(SumP(Set(threeDays, threeDays)).isDefined === true)
-    assert(SumP(Set(threeDays, UnknownPeriod)).isDefined === false)
+    assert(SumP(Set(threeDays, UnknownPeriod())).isDefined === false)
     assert(LastRI(SimpleInterval.of(1998, 2, 16), fridays).isDefined === true)
     assert(AfterRI(Year(1965), fridays).isDefined === true)
   }

--- a/src/test/scala/org/clulab/timenorm/neural/TemporalNeuralParserTest.scala
+++ b/src/test/scala/org/clulab/timenorm/neural/TemporalNeuralParserTest.scala
@@ -7,6 +7,8 @@ import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
+import com.codecommit.antixml.text
+
 
 @RunWith(classOf[JUnitRunner])
 class TemporalNeuralParserTest extends FunSuite with TypesSuite {
@@ -90,5 +92,18 @@ class TemporalNeuralParserTest extends FunSuite with TypesSuite {
     assert(sinceSep2016.charSpan === Some((488, 508)))
     assert(sinceSep2016.start === SimpleInterval.of(2016, 9).start)
     assert(sinceSep2016.end === dct.end)
+  }
+
+  test("no-duplicate-ids") {
+    // in July 2019, for the text below, the parser generated [After even][Next tual][After ly] and the code for
+    // expanding to word boundaries expanded these all to have the span, resulting in <entity> nodes with identical IDs
+    val xml = parser.parseToXML(
+      """
+        |Although BP's involvement in the Russian joint venture has been lucrative, relations with its partners have often been fraught with disagreement. In 2011, the AAR consortium attempted to block a drilling joint venture in the Arctic between BP and Rosneft through the courts and the plan was eventually dropped.
+        |
+        |As well as internal wrangles, BP employees at TNK-BP have fallen foul of Russian authorities.
+      """.stripMargin)
+    val ids = xml \\ "id" \ text
+    assert(ids === ids.distinct)
   }
 }

--- a/src/test/scala/org/clulab/timenorm/neural/TemporalNeuralParserTest.scala
+++ b/src/test/scala/org/clulab/timenorm/neural/TemporalNeuralParserTest.scala
@@ -25,6 +25,10 @@ class TemporalNeuralParserTest extends FunSuite with TypesSuite {
       |A substantial decline in gas revenue since 2014 has
       |contributed to a sharp drop in both foreign currency
       |reserves and the value of the South Sudanese pound.
+      |Between 1 and 30 March 2017, 16,274 South Sudanese
+      |refugees arrived in Gambella, Ethiopia, bringing the
+      |total number of new arrivals since September 2016
+      |to 77,874.
     """.stripMargin.trim,
     Array(
       (0, 10),    // 2018-10-10
@@ -33,6 +37,7 @@ class TemporalNeuralParserTest extends FunSuite with TypesSuite {
       (31, 180),  // South Sudan ... -RRB- .
       (181, 197), // since last March
       (198, 354), // A substantial ... pound.
+      (355, 519), // Between 1 ... 77,874
     ),
     // use a SimpleInterval here so that there's no associated character span
     SimpleInterval(dct.start, dct.end),
@@ -66,6 +71,7 @@ class TemporalNeuralParserTest extends FunSuite with TypesSuite {
   }
 
   test("since-last") {
+    batch(4).foreach(println)
     val Array(march: Interval) = batch(4)
     assert(march.charSpan === Some((181, 197)))
     assert(march.start === SimpleInterval.of(2018, 3, 1).start)
@@ -77,5 +83,13 @@ class TemporalNeuralParserTest extends FunSuite with TypesSuite {
     assert(since2014.charSpan === Some((235, 245)))
     assert(since2014.start === SimpleInterval.of(2014).start)
     assert(since2014.end === dct.end)
+  }
+
+  test("since-month-year") {
+    // the first "Between" is not parsed properly yet, so don't test for that
+    val Some(sinceSep2016: Interval) = batch(6).lastOption
+    assert(sinceSep2016.charSpan === Some((488, 508)))
+    assert(sinceSep2016.start === SimpleInterval.of(2016, 9).start)
+    assert(sinceSep2016.end === dct.end)
   }
 }

--- a/src/test/scala/org/clulab/timenorm/neural/TemporalNeuralParserTest.scala
+++ b/src/test/scala/org/clulab/timenorm/neural/TemporalNeuralParserTest.scala
@@ -71,7 +71,6 @@ class TemporalNeuralParserTest extends FunSuite with TypesSuite {
   }
 
   test("since-last") {
-    batch(4).foreach(println)
     val Array(march: Interval) = batch(4)
     assert(march.charSpan === Some((181, 197)))
     assert(march.start === SimpleInterval.of(2018, 3, 1).start)


### PR DESCRIPTION
All the time operators in Types.scala now have character offsets, and they're read in from the Anafora XML when present. The eventual goal is to be able to get rid of the redundant `TimeExpression` class in `TemporalNeuralParser`.