### PR TITLE
Complete backwards the annotation starting from (start - 1) character

### DIFF
--- a/src/main/scala/org/clulab/timenorm/neural/TemporalNeuralParser.scala
+++ b/src/main/scala/org/clulab/timenorm/neural/TemporalNeuralParser.scala
@@ -229,7 +229,7 @@ class TemporalNeuralParser(modelStream: Option[InputStream] = None) {
 
           // Complete the annotation if the span does not cover the whole token (but only expand over "O" labels)
           val doExpand = (i: Int) => wordCharIndices.contains(i) && predictedLabels.lift(i - snippetStart).contains("O")
-          val wordStart = Iterator.from(start, -1).takeWhile(doExpand).toSeq.lastOption.getOrElse(start)
+          val wordStart = Iterator.from(start - 1, -1).takeWhile(doExpand).toSeq.lastOption.getOrElse(start)
           val wordEnd = Iterator.from(end, +1).takeWhile(doExpand).toSeq.lastOption.map(_ + 1).getOrElse(end)
           (wordStart, wordEnd, label)
         }

--- a/src/test/scala/org/clulab/timenorm/neural/TemporalNeuralParserTest.scala
+++ b/src/test/scala/org/clulab/timenorm/neural/TemporalNeuralParserTest.scala
@@ -31,6 +31,7 @@ class TemporalNeuralParserTest extends FunSuite with TypesSuite {
       |refugees arrived in Gambella, Ethiopia, bringing the
       |total number of new arrivals since September 2016
       |to 77,874.
+      |FOOD PROGRAMME Rome, 2016   The designations employed and the presentation of material in this
     """.stripMargin.trim,
     Array(
       (0, 10),    // 2018-10-10
@@ -40,6 +41,7 @@ class TemporalNeuralParserTest extends FunSuite with TypesSuite {
       (181, 197), // since last March
       (198, 354), // A substantial ... pound.
       (355, 519), // Between 1 ... 77,874
+      (520, 614), // FOOD PROGRAMME ... in this
     ),
     // use a SimpleInterval here so that there's no associated character span
     SimpleInterval(dct.start, dct.end),
@@ -92,6 +94,12 @@ class TemporalNeuralParserTest extends FunSuite with TypesSuite {
     assert(sinceSep2016.charSpan === Some((488, 508)))
     assert(sinceSep2016.start === SimpleInterval.of(2016, 9).start)
     assert(sinceSep2016.end === dct.end)
+  }
+
+  test("fill-incomplete-span-backwards") {
+    val Some(year2016: Interval) = batch(7).headOption
+    assert(year2016.charSpan === Some((541, 545)))
+    assert(year2016 === SimpleInterval.of(2016))
   }
 
   test("no-duplicate-ids") {


### PR DESCRIPTION
`Iterator.from(start, -1)` starts with the `start` character, so `.takeWhile(doExpand)`  returns empty because `start` is not "O".