### PR TITLE
IntersectionRI throws exception if invalid day+month combination

### DIFF
--- a/src/main/scala/org/clulab/timenorm/scate/Types.scala
+++ b/src/main/scala/org/clulab/timenorm/scate/Types.scala
@@ -824,11 +824,12 @@ case class IntersectionRI(repeatingIntervals: Set[RepeatingInterval],
   override val base: TemporalUnit = repeatingIntervals.minBy(_.base.getDuration).base
   override val range: TemporalUnit = repeatingIntervals.maxBy(_.range.getDuration).range
 
+  // Throw an early exception in case of an impossible combination of day and month, e.g. "31 April".
   for {
     month <- repeatingIntervals.collectFirst{ case RepeatingField(ChronoField.MONTH_OF_YEAR, month, _, _) => month }
     day <- repeatingIntervals.collectFirst{ case RepeatingField(ChronoField.DAY_OF_MONTH, day, _, _) => day }
   } {
-    java.time.MonthDay.of(month.toInt, day.toInt) // throws an exception if this is an invalid combination
+    java.time.MonthDay.of(month.toInt, day.toInt)
   }
 
   private val sortedRepeatingIntervals = repeatingIntervals.toList

--- a/src/main/scala/org/clulab/timenorm/scate/Types.scala
+++ b/src/main/scala/org/clulab/timenorm/scate/Types.scala
@@ -824,6 +824,13 @@ case class IntersectionRI(repeatingIntervals: Set[RepeatingInterval],
   override val base: TemporalUnit = repeatingIntervals.minBy(_.base.getDuration).base
   override val range: TemporalUnit = repeatingIntervals.maxBy(_.range.getDuration).range
 
+  for {
+    month <- repeatingIntervals.collectFirst{ case RepeatingField(ChronoField.MONTH_OF_YEAR, month, _, _) => month }
+    day <- repeatingIntervals.collectFirst{ case RepeatingField(ChronoField.DAY_OF_MONTH, day, _, _) => day }
+  } {
+    java.time.MonthDay.of(month.toInt, day.toInt) // throws an exception if this is an invalid combination
+  }
+
   private val sortedRepeatingIntervals = repeatingIntervals.toList
     .sortBy(ri => (ri.range.getDuration, ri.base.getDuration)).reverse
 

--- a/src/test/scala/org/clulab/timenorm/scate/TypesTest.scala
+++ b/src/test/scala/org/clulab/timenorm/scate/TypesTest.scala
@@ -917,6 +917,15 @@ class TypesTest extends FunSuite with TypesSuite {
     val mar31 = IntersectionRI(Set(march, day31))
     val startOf1980 = LocalDateTime.of(1980, 1, 1, 0, 0)
     assert(mar31.following(startOf1980).next === SimpleInterval.of(1980, 3, 31))
+
+    // RI: April 31st
+    intercept[java.time.DateTimeException] {
+      IntersectionRI(Set(
+        RepeatingField(ChronoField.MONTH_OF_YEAR, 4),
+        RepeatingField(ChronoField.DAY_OF_MONTH, 31)
+      ))
+      fail("April 31st should throw an exception")
+    }
   }
 
   test("IntersectionI") {


### PR DESCRIPTION
Throw an early exception in case of an impossible combination of day and month, e.g.  "31 April".
The solution is taken from https://github.com/clulab/timenorm/issues/47