### PR TITLE
Check if startInterval ends before endInterval in Between operator

### DIFF
--- a/src/main/scala/org/clulab/timenorm/scate/Types.scala
+++ b/src/main/scala/org/clulab/timenorm/scate/Types.scala
@@ -562,7 +562,7 @@ case class Between(startInterval: Interval,
                    startIncluded: Boolean = false,
                    endIncluded: Boolean = false,
                    triggerCharSpan: Option[(Int, Int)] = None) extends Interval {
-  val isDefined: Boolean = startInterval.isDefined && endInterval.isDefined
+  val isDefined: Boolean = startInterval.isDefined && endInterval.isDefined && startInterval.end.isBefore(endInterval.start)
   val charSpan: Option[(Int, Int)] = maxSpan(Seq(startInterval.charSpan, endInterval.charSpan, triggerCharSpan))
   lazy val start: LocalDateTime = if (startIncluded) startInterval.start else startInterval.end
   lazy val end: LocalDateTime = if (endIncluded) endInterval.end else endInterval.start

--- a/src/test/scala/org/clulab/timenorm/scate/TypesTest.scala
+++ b/src/test/scala/org/clulab/timenorm/scate/TypesTest.scala
@@ -253,7 +253,7 @@ class TypesTest extends FunSuite with TypesSuite {
     assert(between.start === LocalDateTime.of(2000, 1, 1, 0, 0, 0, 0))
     assert(between.end === LocalDateTime.of(2002, 1, 1, 0, 0, 0, 0))
 
-    // If startInterval ends after startInterval the operator should be not defined.
+    // If startInterval ends after endInterval starts the operator should be not defined.
     val incorrect_between = Between(interval2, interval1)
     assert(incorrect_between.isDefined === false)
   }

--- a/src/test/scala/org/clulab/timenorm/scate/TypesTest.scala
+++ b/src/test/scala/org/clulab/timenorm/scate/TypesTest.scala
@@ -252,6 +252,10 @@ class TypesTest extends FunSuite with TypesSuite {
 
     assert(between.start === LocalDateTime.of(2000, 1, 1, 0, 0, 0, 0))
     assert(between.end === LocalDateTime.of(2002, 1, 1, 0, 0, 0, 0))
+
+    // If startInterval ends after startInterval the operator should be not defined.
+    val incorrect_between = Between(interval2, interval1)
+    assert(incorrect_between.isDefined === false)
   }
 
   test("NthP") {


### PR DESCRIPTION
Additional check added for `Between.isDefined`:
 * If the startInterval ends before the endInterval starts the Between operator should be not defined.
   E.g. `Between(Year(2002), Year(1999)`.

