### PR TITLE
Regex for unicode-32 characters. Repeating operators. IntersectionRI.

### DIFF
--- a/src/main/scala/org/clulab/timenorm/scate/TemporalNeuralParser.scala
+++ b/src/main/scala/org/clulab/timenorm/scate/TemporalNeuralParser.scala
@@ -163,7 +163,7 @@ class TemporalNeuralParser(modelStream: Option[InputStream] = None) extends Auto
   }
 
   def parseBatchToXML(text: String, spans: Array[(Int, Int)]): Array[Elem] = {
-    val antixmlCleanedText = """[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD]""".r.replaceAllIn(text, " ")
+    val antixmlCleanedText = """[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD]""".r.replaceAllIn(text, " " * _.group(0).length)
 
     val allTimeSpans = identifyBatch(text, spans)
     val timeSpanToId = allTimeSpans.flatten.zipWithIndex.toMap.mapValues(i => s"$i@id")
@@ -249,7 +249,7 @@ class TemporalNeuralParser(modelStream: Option[InputStream] = None) extends Auto
     // for each batch, combine the different time operators into a single array
     for (i <- expandedTexts.indices.toArray) yield {
       val operators = nonOperators(i) ++ expOperators(i) ++ impOperators(i)
-      operators.sortBy { case (start, _, _) => start }
+      operators.sortBy { case (start, _, _) => start }.distinct
     }
   }
 

--- a/src/main/scala/org/clulab/timenorm/scate/Types.scala
+++ b/src/main/scala/org/clulab/timenorm/scate/Types.scala
@@ -849,11 +849,10 @@ case class IntersectionRI(repeatingIntervals: Set[RepeatingInterval],
         startPoint = startPoint.minus(1, range)
       } while(iterators.exists(startPoint isAfter _.head.start))
       val firstInterval = iterators.head.next
-      val tup = iterators.tail.map(_.span(_.start isAfter startPoint)).unzip
-      val othersAfterStart = tup._1.map(_.toList)
-      iterators = iterators.head :: tup._2.map(_.buffered)
+      val (othersAfterStart, rest) = iterators.tail.map(_.span(_.start isAfter startPoint)).unzip
+      iterators = iterators.head :: rest.map(_.buffered)
 
-      othersAfterStart.iterator.foldLeft(List(firstInterval)) {
+      othersAfterStart.map(_.toList).iterator.foldLeft(List(firstInterval)) {
         (intersectedIntervals, newIntervals) => newIntervals.filter(overlapsWith(_, intersectedIntervals))
       }
     }.flatten
@@ -873,11 +872,10 @@ case class IntersectionRI(repeatingIntervals: Set[RepeatingInterval],
         startPoint = startPoint.plus(1, range)
       } while(iterators.exists(startPoint isBefore _.head.end))
       val firstInterval = iterators.head.next
-      val tup = iterators.tail.map(_.span(_.end isBefore startPoint)).unzip
-      val othersBeforeStart = tup._1.map(_.toList)
-      iterators = iterators.head :: tup._2.map(_.buffered)
+      val (othersBeforeStart, rest) = iterators.tail.map(_.span(_.start isBefore startPoint)).unzip
+      iterators = iterators.head :: rest.map(_.buffered)
 
-      othersBeforeStart.iterator.foldLeft(List(firstInterval)) {
+      othersBeforeStart.map(_.toList).iterator.foldLeft(List(firstInterval)) {
         (intersectedIntervals, newIntervals) => newIntervals.filter(overlapsWith(_, intersectedIntervals))
       }
     }.flatten

--- a/src/test/scala/org/clulab/timenorm/scate/TypesTest.scala
+++ b/src/test/scala/org/clulab/timenorm/scate/TypesTest.scala
@@ -930,6 +930,34 @@ class TypesTest extends FunSuite with TypesSuite {
       ))
       fail("April 31st should throw an exception")
     }
+
+
+    // In the following cases IntersectRI must skip one range unit.
+    //Interval: March 1, 2012
+    val mar312012 = SimpleInterval.of(2012, 3, 1)
+    //RepeatingInterval: The evening of the 31st
+    val intersectRIWithSkips = IntersectionRI(
+                                Set(
+                                  RepeatingField(ChronoField.DAY_OF_MONTH, 31),
+                                  RepeatingField(org.clulab.time.EVENING_OF_DAY, 1)
+                                ))
+
+    val followingWithSkips = intersectRIWithSkips.following(mar312012.start)
+    //Expected: March 31 2012 @ 1700, April 1 2012 @ 0000
+    next = followingWithSkips.next
+    assert(next.start === LocalDateTime.of(2012, 3, 31, 17, 0))
+    assert(next.end === LocalDateTime.of(2012, 4, 1, 0, 0))
+
+    //Expected: May 31 2012 @ 1700, June 1 2012 @ 0000
+    next = followingWithSkips.next
+    assert(next.start === LocalDateTime.of(2012, 5, 31, 17, 0))
+    assert(next.end === LocalDateTime.of(2012, 6, 1, 0, 0))
+
+    //Expected: January 31 2012 @ 1700, February 1 2012 @ 0000
+    val precedingWithSkips = intersectRIWithSkips.preceding(mar312012.start)
+    next = precedingWithSkips.next
+    assert(next.start === LocalDateTime.of(2012, 1, 31, 17, 0))
+    assert(next.end === LocalDateTime.of(2012, 2, 1, 0, 0))
   }
 
   test("IntersectionI") {


### PR DESCRIPTION
- Regex in neural parser replaces the correct length of unicode-32 characters . Solves: https://github.com/clulab/timenorm/issues/53
- `following` and `preceding` functions of `IntersectionRI` skip properly not valid `RepeatingInterval`s. Solves: https://github.com/clulab/timenorm/issues/54
- Remove repeating operators for the same span in the neural parser. Solves: https://github.com/clulab/timenorm/issues/55
